### PR TITLE
Default quota paramater is missing after the recreation of the java server protobuf server interfaces

### DIFF
--- a/java/servers/src/org/xtreemfs/common/clients/Client.java
+++ b/java/servers/src/org/xtreemfs/common/clients/Client.java
@@ -124,7 +124,7 @@ public class Client {
             MRCServiceClient m = new MRCServiceClient(mdClient, mrcUUID.getAddress());
             r2 = m.xtreemfs_mkvol(null, authentication, credentials, accessCtrlPolicy, sp, "", permissions,
                 volumeName, credentials.getUsername(), credentials.getGroups(0),
-                new LinkedList<KeyValuePair>());
+                new LinkedList<KeyValuePair>(), 0);
             r2.get();
             
         } catch (InterruptedException ex) {
@@ -147,7 +147,7 @@ public class Client {
             MRCServiceClient m = new MRCServiceClient(mdClient, uuid.getAddress());
             r = m.xtreemfs_mkvol(uuid.getAddress(), authentication, credentials, accessCtrlPolicy, sp, "", permissions,
                 volumeName, credentials.getUsername(), credentials.getGroups(0),
-                new LinkedList<KeyValuePair>());
+                new LinkedList<KeyValuePair>(), 0);
             r.get();
             
         } catch (InterruptedException ex) {

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/DIR.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/DIR.java
@@ -367,8 +367,8 @@ public final class DIR {
      * <code>required string match_network = 6;</code>
      *
      * <pre>
-     * Matching network, unused at the moment.
-     * Must be "*".
+     * Matching network. There has to exist exactly one default address 
+     * accessible from any network for which this is set to "*".
      * </pre>
      */
     boolean hasMatchNetwork();
@@ -376,8 +376,8 @@ public final class DIR {
      * <code>required string match_network = 6;</code>
      *
      * <pre>
-     * Matching network, unused at the moment.
-     * Must be "*".
+     * Matching network. There has to exist exactly one default address 
+     * accessible from any network for which this is set to "*".
      * </pre>
      */
     java.lang.String getMatchNetwork();
@@ -385,8 +385,8 @@ public final class DIR {
      * <code>required string match_network = 6;</code>
      *
      * <pre>
-     * Matching network, unused at the moment.
-     * Must be "*".
+     * Matching network. There has to exist exactly one default address 
+     * accessible from any network for which this is set to "*".
      * </pre>
      */
     com.google.protobuf.ByteString
@@ -795,8 +795,8 @@ public final class DIR {
      * <code>required string match_network = 6;</code>
      *
      * <pre>
-     * Matching network, unused at the moment.
-     * Must be "*".
+     * Matching network. There has to exist exactly one default address 
+     * accessible from any network for which this is set to "*".
      * </pre>
      */
     public boolean hasMatchNetwork() {
@@ -806,8 +806,8 @@ public final class DIR {
      * <code>required string match_network = 6;</code>
      *
      * <pre>
-     * Matching network, unused at the moment.
-     * Must be "*".
+     * Matching network. There has to exist exactly one default address 
+     * accessible from any network for which this is set to "*".
      * </pre>
      */
     public java.lang.String getMatchNetwork() {
@@ -828,8 +828,8 @@ public final class DIR {
      * <code>required string match_network = 6;</code>
      *
      * <pre>
-     * Matching network, unused at the moment.
-     * Must be "*".
+     * Matching network. There has to exist exactly one default address 
+     * accessible from any network for which this is set to "*".
      * </pre>
      */
     public com.google.protobuf.ByteString
@@ -1750,8 +1750,8 @@ public final class DIR {
        * <code>required string match_network = 6;</code>
        *
        * <pre>
-       * Matching network, unused at the moment.
-       * Must be "*".
+       * Matching network. There has to exist exactly one default address 
+       * accessible from any network for which this is set to "*".
        * </pre>
        */
       public boolean hasMatchNetwork() {
@@ -1761,8 +1761,8 @@ public final class DIR {
        * <code>required string match_network = 6;</code>
        *
        * <pre>
-       * Matching network, unused at the moment.
-       * Must be "*".
+       * Matching network. There has to exist exactly one default address 
+       * accessible from any network for which this is set to "*".
        * </pre>
        */
       public java.lang.String getMatchNetwork() {
@@ -1780,8 +1780,8 @@ public final class DIR {
        * <code>required string match_network = 6;</code>
        *
        * <pre>
-       * Matching network, unused at the moment.
-       * Must be "*".
+       * Matching network. There has to exist exactly one default address 
+       * accessible from any network for which this is set to "*".
        * </pre>
        */
       public com.google.protobuf.ByteString
@@ -1801,8 +1801,8 @@ public final class DIR {
        * <code>required string match_network = 6;</code>
        *
        * <pre>
-       * Matching network, unused at the moment.
-       * Must be "*".
+       * Matching network. There has to exist exactly one default address 
+       * accessible from any network for which this is set to "*".
        * </pre>
        */
       public Builder setMatchNetwork(
@@ -1819,8 +1819,8 @@ public final class DIR {
        * <code>required string match_network = 6;</code>
        *
        * <pre>
-       * Matching network, unused at the moment.
-       * Must be "*".
+       * Matching network. There has to exist exactly one default address 
+       * accessible from any network for which this is set to "*".
        * </pre>
        */
       public Builder clearMatchNetwork() {
@@ -1833,8 +1833,8 @@ public final class DIR {
        * <code>required string match_network = 6;</code>
        *
        * <pre>
-       * Matching network, unused at the moment.
-       * Must be "*".
+       * Matching network. There has to exist exactly one default address 
+       * accessible from any network for which this is set to "*".
        * </pre>
        */
       public Builder setMatchNetworkBytes(

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/DIRServiceClient.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/DIRServiceClient.java
@@ -1,5 +1,5 @@
-//automatically generated from DIR.proto at Mon Nov 11 11:46:59 CET 2013
-//(c) 2013. See LICENSE file for details.
+//automatically generated from DIR.proto at Thu Jul 10 14:56:46 CEST 2014
+//(c) 2014. See LICENSE file for details.
 
 package org.xtreemfs.pbrpc.generatedinterfaces;
 

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/DIRServiceConstants.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/DIRServiceConstants.java
@@ -1,5 +1,5 @@
-//automatically generated from DIR.proto at Mon Nov 11 11:46:59 CET 2013
-//(c) 2013. See LICENSE file for details.
+//automatically generated from DIR.proto at Thu Jul 10 14:56:46 CEST 2014
+//(c) 2014. See LICENSE file for details.
 
 package org.xtreemfs.pbrpc.generatedinterfaces;
 

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/MRCServiceClient.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/MRCServiceClient.java
@@ -1,5 +1,5 @@
-//automatically generated from MRC.proto at Mon Nov 11 11:46:59 CET 2013
-//(c) 2013. See LICENSE file for details.
+//automatically generated from MRC.proto at Thu Jul 10 14:56:46 CEST 2014
+//(c) 2014. See LICENSE file for details.
 
 package org.xtreemfs.pbrpc.generatedinterfaces;
 
@@ -370,8 +370,8 @@ public class MRCServiceClient {
          return response;
     }
 
-    public RPCResponse xtreemfs_mkvol(InetSocketAddress server, Auth authHeader, UserCredentials userCreds, GlobalTypes.AccessControlPolicyType access_control_policy, GlobalTypes.StripingPolicy default_striping_policy, String id, int mode, String name, String owner_group_id, String owner_user_id, List<GlobalTypes.KeyValuePair> attrs) throws IOException {
-         final MRC.Volume msg = MRC.Volume.newBuilder().setAccessControlPolicy(access_control_policy).setDefaultStripingPolicy(default_striping_policy).setId(id).setMode(mode).setName(name).setOwnerGroupId(owner_group_id).setOwnerUserId(owner_user_id).addAllAttrs(attrs).build();
+    public RPCResponse xtreemfs_mkvol(InetSocketAddress server, Auth authHeader, UserCredentials userCreds, GlobalTypes.AccessControlPolicyType access_control_policy, GlobalTypes.StripingPolicy default_striping_policy, String id, int mode, String name, String owner_group_id, String owner_user_id, List<GlobalTypes.KeyValuePair> attrs, long quota) throws IOException {
+         final MRC.Volume msg = MRC.Volume.newBuilder().setAccessControlPolicy(access_control_policy).setDefaultStripingPolicy(default_striping_policy).setId(id).setMode(mode).setName(name).setOwnerGroupId(owner_group_id).setOwnerUserId(owner_user_id).addAllAttrs(attrs).setQuota(quota).build();
          return xtreemfs_mkvol(server, authHeader, userCreds,msg);
     }
 

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/MRCServiceConstants.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/MRCServiceConstants.java
@@ -1,5 +1,5 @@
-//automatically generated from MRC.proto at Mon Nov 11 11:46:59 CET 2013
-//(c) 2013. See LICENSE file for details.
+//automatically generated from MRC.proto at Thu Jul 10 14:56:46 CEST 2014
+//(c) 2014. See LICENSE file for details.
 
 package org.xtreemfs.pbrpc.generatedinterfaces;
 

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/OSDServiceClient.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/OSDServiceClient.java
@@ -1,5 +1,5 @@
-//automatically generated from OSD.proto at Mon Nov 11 11:46:59 CET 2013
-//(c) 2013. See LICENSE file for details.
+//automatically generated from OSD.proto at Thu Jul 10 14:56:46 CEST 2014
+//(c) 2014. See LICENSE file for details.
 
 package org.xtreemfs.pbrpc.generatedinterfaces;
 

--- a/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/OSDServiceConstants.java
+++ b/java/servers/src/org/xtreemfs/pbrpc/generatedinterfaces/OSDServiceConstants.java
@@ -1,5 +1,5 @@
-//automatically generated from OSD.proto at Mon Nov 11 11:46:59 CET 2013
-//(c) 2013. See LICENSE file for details.
+//automatically generated from OSD.proto at Thu Jul 10 14:56:46 CEST 2014
+//(c) 2014. See LICENSE file for details.
 
 package org.xtreemfs.pbrpc.generatedinterfaces;
 

--- a/java/servers/test/org/xtreemfs/common/clients/ClientTest.java
+++ b/java/servers/test/org/xtreemfs/common/clients/ClientTest.java
@@ -61,7 +61,7 @@ public class ClientTest {
 
         RPCResponse r = testEnv.getMrcClient().xtreemfs_mkvol(testEnv.getMRCAddress(), RPCAuthentication.authNone, uc,
                 AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, SetupUtils.getStripingPolicy(64, 1), "", 0777,
-                VOLUME_NAME, "test", "test", new LinkedList<KeyValuePair>());
+                VOLUME_NAME, "test", "test", new LinkedList<KeyValuePair>(), 0);
         r.get();
         r.freeBuffers();
     }

--- a/java/servers/test/org/xtreemfs/common/clients/ReplicatedClientTest.java
+++ b/java/servers/test/org/xtreemfs/common/clients/ReplicatedClientTest.java
@@ -65,7 +65,7 @@ public class ReplicatedClientTest {
         uc = UserCredentials.newBuilder().setUsername("test").addGroups("test").build();
 
         RPCResponse r = testEnv.getMrcClient().xtreemfs_mkvol(testEnv.getMRCAddress(), RPCAuthentication.authNone, uc,
-            AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, SetupUtils.getStripingPolicy(1, 64), "", 0777, VOLUME_NAME, "test", "test", new LinkedList<KeyValuePair>());
+            AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, SetupUtils.getStripingPolicy(1, 64), "", 0777, VOLUME_NAME, "test", "test", new LinkedList<KeyValuePair>(), 0);
         r.get();
         r.freeBuffers();
     }

--- a/java/servers/test/org/xtreemfs/test/mrc/MRCTest.java
+++ b/java/servers/test/org/xtreemfs/test/mrc/MRCTest.java
@@ -111,7 +111,7 @@ public class MRCTest {
                 String name = "vol-" + j;
                 invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
                         AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-                        name, "", "", getKVList("i", String.valueOf(i))));
+                        name, "", "", getKVList("i", String.valueOf(i)), 0));
             }
 
             // Check number of created volumes
@@ -124,7 +124,7 @@ public class MRCTest {
                 try {
                     invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
                             AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-                            name, "", "", getKVList("i", String.valueOf(i))));
+                            name, "", "", getKVList("i", String.valueOf(i)), 0));
                     fail();
                 } catch (Exception ex) {
                     vols = invokeSync(client.xtreemfs_lsvol(mrcAddress, RPCAuthentication.authNone, uc));
@@ -159,7 +159,7 @@ public class MRCTest {
             
             invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
                 AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-                name, "", "", getKVList("bla", "blub")));
+                name, "", "", getKVList("bla", "blub"), 0));
             
             volNames.add(name);
         }
@@ -207,7 +207,7 @@ public class MRCTest {
         // create and delete a volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-            volumeName, "", "", getKVList("bla", "blub")));
+            volumeName, "", "", getKVList("bla", "blub"), 0));
         
         Volumes localVols = invokeSync(client.xtreemfs_lsvol(mrcAddress, RPCAuthentication.authNone, uc));
         assertEquals(1, localVols.getVolumesCount());
@@ -222,7 +222,7 @@ public class MRCTest {
         // create a volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0775,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         // create some files and directories
         invokeSync(client.mkdir(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "myDir", 0775));
@@ -305,7 +305,7 @@ public class MRCTest {
         
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         invokeSync(client.readdir(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "/", -1, 1000,
             false, 0));
     }
@@ -320,7 +320,7 @@ public class MRCTest {
         
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         // create a file and add some user attributes
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "test.txt",
@@ -442,7 +442,7 @@ public class MRCTest {
         
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         // create a file and add some user attributes
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "test.txt",
@@ -471,7 +471,7 @@ public class MRCTest {
         
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "test.txt",
             FileAccessManager.O_CREAT, 0, 0, getDefaultCoordinates()));
@@ -495,7 +495,7 @@ public class MRCTest {
         
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "test1.txt",
             FileAccessManager.O_CREAT, 0, 0, getDefaultCoordinates()));
@@ -577,7 +577,7 @@ public class MRCTest {
         
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "test.txt",
             FileAccessManager.O_CREAT, 0774, 0, getDefaultCoordinates()));
@@ -670,7 +670,7 @@ public class MRCTest {
         
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         final String uid2 = "bla";
         final List<String> gids2 = createGIDs("groupY");
@@ -697,7 +697,7 @@ public class MRCTest {
         
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         // create some files and directories
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "test.txt",
@@ -821,7 +821,7 @@ public class MRCTest {
         // create a volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc1,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0,
-            noACVolumeName, "", "", getKVList()));
+            noACVolumeName, "", "", getKVList(), 0));
         
         // test chown
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc1, noACVolumeName, "chownTestFile",
@@ -856,7 +856,7 @@ public class MRCTest {
         // create a volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc1,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_VOLUME, getDefaultStripingPolicy(), "", 0700,
-            volACVolumeName, "", "", getKVList()));
+            volACVolumeName, "", "", getKVList(), 0));
         
         // create a new directory: should succeed for user1, fail
         // for user2
@@ -876,7 +876,7 @@ public class MRCTest {
         // create a volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc1,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-            posixVolName, "", "", getKVList()));
+            posixVolName, "", "", getKVList(), 0));
         
         invokeSync(client.setattr(mrcAddress, RPCAuthentication.authNone, uc1, posixVolName, "",
             createChmodStat(0700), Setattrs.SETATTR_MODE.getNumber()));
@@ -996,7 +996,7 @@ public class MRCTest {
         invokeSync(client.xtreemfs_rmvol(mrcAddress, RPCAuthentication.authNone, uc1, posixVolName));
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc1,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-            posixVolName, "", "", getKVList()));
+            posixVolName, "", "", getKVList(), 0));
         
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc1, posixVolName, "someFile.txt",
             FileAccessManager.O_CREAT, 224, 0, getDefaultCoordinates()));
@@ -1065,7 +1065,7 @@ public class MRCTest {
         // create a new file in a new volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, getDefaultStripingPolicy(), "", 0,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc, volumeName, fileName,
             FileAccessManager.O_CREAT, 0, 0, getDefaultCoordinates()));
@@ -1168,7 +1168,7 @@ public class MRCTest {
         
         // create a new file in a directory in a new volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
-            AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, sp1, "", 0, volumeName, "", "", getKVList()));
+            AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, sp1, "", 0, volumeName, "", "", getKVList(), 0));
         
         invokeSync(client.mkdir(mrcAddress, RPCAuthentication.authNone, uc, volumeName, dirName, 0));
         invokeSync(client.open(mrcAddress, RPCAuthentication.authNone, uc, volumeName, fileName1,
@@ -1233,7 +1233,7 @@ public class MRCTest {
         
         // create a new file in a directory in a new volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
-            AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, sp, "", 0, volumeName, "", "", getKVList()));
+            AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL, sp, "", 0, volumeName, "", "", getKVList(), 0));
         
         invokeSync(client.setxattr(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "",
             "xtreemfs.default_rp", "", ByteString.copyFrom(Converter.replicationPolicyToJSONString(rp).getBytes()), 0));
@@ -1273,7 +1273,7 @@ public class MRCTest {
         // create a volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
             AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-            volumeName, "", "", getKVList()));
+            volumeName, "", "", getKVList(), 0));
         
         // auto-assign three (two more) replicas to each newly-created file
         ReplicationPolicy rp = new ReplicationPolicy() {

--- a/java/servers/test/org/xtreemfs/test/mrc/SnapshotTest.java
+++ b/java/servers/test/org/xtreemfs/test/mrc/SnapshotTest.java
@@ -143,7 +143,7 @@ public class SnapshotTest extends TestCase {
         // create a volume
         invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
                 AccessControlPolicyType.ACCESS_CONTROL_POLICY_POSIX, getDefaultStripingPolicy(), "", 0775,
-                volumeName, "", "", new LinkedList<KeyValuePair>()));
+                volumeName, "", "", new LinkedList<KeyValuePair>(), 0));
 
         // enable snapshots on the volume
         invokeSync(client.setxattr(mrcAddress, RPCAuthentication.authNone, uc, volumeName, "",


### PR DESCRIPTION
There occur errors in the java servers, after rebuilding the java protobuf interfaces, because the quota param is missing.

This commit contains the refreshed java protobuf interfaces and adds 0 as a default quota parameter to every xtreemfs_mkvol() call.
