### PR TITLE
test: added additional test calls for access which currently fail

### DIFF
--- a/java/servers/test/org/xtreemfs/test/mrc/MRCTest.java
+++ b/java/servers/test/org/xtreemfs/test/mrc/MRCTest.java
@@ -898,6 +898,26 @@ public class MRCTest {
         // check 'access' call
         
         try {
+            invokeSync(client.access(mrcAddress, RPCAuthentication.authNone, uc1, posixVolName, "grsasd",
+                    ACCESS_FLAGS.ACCESS_FLAGS_F_OK.getNumber()));
+            fail("access should have been denied");
+        } catch (PBRPCException exc) {
+            if (exc.getPOSIXErrno() != POSIXErrno.POSIX_ERROR_EACCES) {
+                fail("wrong error returned");
+            }
+        }
+
+        try {
+            invokeSync(client.access(mrcAddress, RPCAuthentication.authNone, uc1, posixVolName, "grsasd",
+                    ACCESS_FLAGS.ACCESS_FLAGS_R_OK.getNumber()));
+            fail("access should have been denied");
+        } catch (PBRPCException exc) {
+            if (exc.getPOSIXErrno() != POSIXErrno.POSIX_ERROR_EACCES) {
+                fail("wrong error returned");
+            }
+        }
+
+        try {
             invokeSync(client.access(mrcAddress, RPCAuthentication.authNone, uc2, posixVolName, "grsasd",
                 ACCESS_FLAGS.ACCESS_FLAGS_F_OK.getNumber()));
             fail("access should have been denied");


### PR DESCRIPTION
There seems to be two problems with the access call:
1. the ACCESS_FLAGS_F_OK is not recognized as it is 0
2. ACCESS_FLAGS_R_OK, ACCESS_FLAGS_W_OK and ACCESS_FLAGS_X_OK do not test if the file exist

I have added currently failing tests for both.
