### PR TITLE
Run Valgrind memory-leak checks for C++ Unit Tests on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: openjdk6
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y libboost-all-dev libfuse-dev fuse libssl-dev libattr1-dev make cmake automake python
+  - sudo apt-get install -y libboost-all-dev libfuse-dev fuse libssl-dev libattr1-dev make cmake automake python valgrind
 
 before_script:
   - TEST_DIR="/tmp/xtreemfs_xtestenv"
@@ -18,6 +18,8 @@ script:
 after_failure:
   - JUNIT_RESULT=`./contrib/travis/parse_results.py $TEST_DIR/result.json 'JUnit tests'`
   - CPP_RESULT=`./contrib/travis/parse_results.py $TEST_DIR/result.json 'C++ Unit Tests'`
-  - if [ $JUNIT_RESULT = "false" ]; then cat $TEST_DIR/log/junit.log; fi
-  - if [ $CPP_RESULT = "false" ]; then cat cpp/build/Testing/Temporary/LastTest.log; fi
+  - VALGRIND_RESULT=`./contrib/travis/parse_results.py $TEST_DIR/result.json 'Valgrind memory-leak check for C++ Unit Tests'`
+  - if [[ $JUNIT_RESULT = "false" ]]; then cat $TEST_DIR/log/junit.log; fi
+  - if [[ $CPP_RESULT = "false" ]]; then cat cpp/build/Testing/Temporary/LastTest.log; fi
+  - if [[ $VALGRIND_RESULT = "false" ]]; then cat $TEST_DIR/log/valgrind.log; fi
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -286,7 +286,7 @@ Tests = [
         'name': 'Valgrind memory-leak check for C++ Unit Tests',
         'file': 'cpp_unit_tests_valgrind.sh',
         'VolumeConfigs': [],
-        'TestSets': [ 'full' ]
+        'TestSets': [ 'full', 'travis' ]
     },
     {
         'name': 'mkfs-lsfs-rmfs.xtreemfs test',


### PR DESCRIPTION
Extending the travis build to run the valgrind tests is working, but the build fails due to a leak in `test_system_user_mapping_unix`
See https://travis-ci.org/xtreemfs/xtreemfs/builds/42410647 for reference.
