### PR TITLE
servers: cpp: Clarifiy GetSuitableOSDs interface documentation.

### DIFF
--- a/cpp/include/libxtreemfs/volume.h
+++ b/cpp/include/libxtreemfs/volume.h
@@ -496,12 +496,14 @@ class Volume {
       const std::string& path,
       const std::string& osd_uuid) = 0;
 
-  /** Adds to "list_of_osd_uuids" up to "number_of_osds" UUIDs of all available
-   *  OSDs where the file (described by "path") can be placed.
+  /** Adds all available OSDs where the file (described by "path") can be
+   *  placed to "list_of_osd_uuids"
    *
    * @param user_credentials    Username and groups of the user.
    * @param path                Path to the file.
-   * @param number_of_osds      Maximum number of OSDs which will be returned.
+   * @param number_of_osds      Number of OSDs required in a valid group. This
+   *                            is only relevant for grouping and will be
+   *                            ignored by filtering and sorting policies.
    * @param list_of_osd_uuids[out]  List of strings to which the UUIDs will be
    *                                appended.
    *

--- a/interface/xtreemfs/MRC.proto
+++ b/interface/xtreemfs/MRC.proto
@@ -467,7 +467,8 @@ message xtreemfs_get_suitable_osdsRequest {
   // or path and volume_name to file.
   optional string path = 3;
   optional string volume_name = 4;
-  // the number of OSDs for the new replicas
+  // the number of OSDs required in a valid group
+  // ignored by filtering and sorting policies
   required fixed32 num_osds = 2;
 }
 

--- a/java/servers/src/org/xtreemfs/common/libxtreemfs/Volume.java
+++ b/java/servers/src/org/xtreemfs/common/libxtreemfs/Volume.java
@@ -540,15 +540,15 @@ public interface  Volume {
             throws IOException, PosixErrorException, AddressToUUIDNotFoundException;
 
     /**
-     * Adds to "listOfOsdUuids" up to "numberOfOsds" UUIDs of all available OSDs where the file (described by
-     * "path") can be placed.
+     * Returns a list of all available OSDs where the file (described by "path") can be placed.
      * 
      * @param userCredentials
      *            Username and groups of the user.
      * @param path
      *            Path to the file.
      * @param numberOfOsds
-     *            Maximum number of OSDs which will be returned.
+     *            Number of OSDs required in a valid group. This is only relevant for grouping and will be ignored by
+     *            filtering and sorting policies.
      * 
      * @throws AddressToUUIDNotFoundException
      * @throws {@link IOException}

--- a/java/servers/src/org/xtreemfs/mrc/osdselection/OSDSelectionPolicy.java
+++ b/java/servers/src/org/xtreemfs/mrc/osdselection/OSDSelectionPolicy.java
@@ -33,7 +33,8 @@ public interface OSDSelectionPolicy {
      * @param currentXLoc
      *            the current X-Locations list
      * @param numOSDs
-     *            the number of OSDs to select
+     *            the number of OSDs required in a valid group. This is only relevant for grouping and will be ignored
+     *            by filtering and sorting policies.
      * @return a list of selected OSDs
      */
     public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress clientIP, VivaldiCoordinates clientCoords,

--- a/java/servers/src/org/xtreemfs/mrc/osdselection/OSDStatusManager.java
+++ b/java/servers/src/org/xtreemfs/mrc/osdselection/OSDStatusManager.java
@@ -19,7 +19,6 @@ import org.xtreemfs.foundation.LifeCycleThread;
 import org.xtreemfs.foundation.logging.Logging;
 import org.xtreemfs.foundation.logging.Logging.Category;
 import org.xtreemfs.foundation.pbrpc.client.RPCAuthentication;
-import org.xtreemfs.foundation.pbrpc.client.RPCResponse;
 import org.xtreemfs.foundation.util.OutputUtils;
 import org.xtreemfs.mrc.MRCRequestDispatcher;
 import org.xtreemfs.mrc.database.DatabaseException;
@@ -220,12 +219,6 @@ public class OSDStatusManager extends LifeCycleThread implements VolumeChangeLis
         // return a set of OSDs
         ServiceSet.Builder result = vol.filterByOSDSelectionPolicy(knownOSDs, clientIP, clientCoords,
             currentXLoc, numOSDs);
-        
-        if (result.getServicesCount() == 0) {
-            String osds = "";
-            for (Service s : result.getServicesList())
-                osds += s.getUuid() + ", " + s.getData() + " ";
-        }
         
         return result;
     }

--- a/java/servers/src/org/xtreemfs/mrc/osdselection/SortVivaldiPolicy.java
+++ b/java/servers/src/org/xtreemfs/mrc/osdselection/SortVivaldiPolicy.java
@@ -36,8 +36,6 @@ public class SortVivaldiPolicy implements OSDSelectionPolicy {
         if (allOSDs == null)
             return null;
         
-        // TOFIX:What's up with numOSDs?
-        
         // Calculate the distances from the client to all the OSDs
         Hashtable<String, Double> distances = new Hashtable<String, Double>();
         

--- a/java/servers/src/org/xtreemfs/mrc/osdselection/VolumeOSDFilter.java
+++ b/java/servers/src/org/xtreemfs/mrc/osdselection/VolumeOSDFilter.java
@@ -162,12 +162,8 @@ public class VolumeOSDFilter {
                         "could not find OSD selection policy with ID=%d, will be ignored", id);
                 continue;
             }
-            try {
-                result = policy.getOSDs(result, clientIP, clientCoords, currentXLoc, numOSDs);
-            } catch (Exception exc) {
-                Logging.logMessage(Logging.LEVEL_WARN, Category.misc, "an error occurred while executing policy %d", id);
-                Logging.logError(Logging.LEVEL_WARN, this, exc);
-            }
+
+            result = policy.getOSDs(result, clientIP, clientCoords, currentXLoc, numOSDs);
         }
 
         return result;

--- a/java/servers/src/org/xtreemfs/utils/xtfs_scrub/FileScrubber.java
+++ b/java/servers/src/org/xtreemfs/utils/xtfs_scrub/FileScrubber.java
@@ -307,7 +307,7 @@ public class FileScrubber implements Runnable {
             Replica.Builder newReplicaBuilder = Replica.newBuilder();
 
             // set OSDs
-            newReplicaBuilder.addAllOsdUuids(osds);
+            newReplicaBuilder.addAllOsdUuids(osds.subList(0, replica.getStripingPolicy().getWidth()));
 
             // recycle the replication flags of the removed replica(except for the complete
             // flag)


### PR DESCRIPTION
The numberOfOsds paramater is only relevant for grouping policies and will be
ignored by filtering and sorting policies. If a particular number of OSDs is
required by the caller, the returned list has to be reduced by the caller.

This lead to an erorr in the FileScrubber, where every suitable OSD was
assigned to new replicas.
