### PR TITLE
Parallel Execution of Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: java
 
 jdk: openjdk6
 
+env:
+  - TEST_SUITE=travis-junit
+  - TEST_SUITE=travis-cpp
+  - TEST_SUITE=travis-valgrind
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y libboost-all-dev libfuse-dev fuse libssl-dev libattr1-dev make cmake automake python valgrind
@@ -11,9 +16,8 @@ before_script:
   - XTREEMFS_DIR=`pwd`
 
 script:
-  - make server
-  - BUILD_CLIENT_TESTS=true make client_debug
-  - ./tests/xtestenv --clean-test-dir -x $XTREEMFS_DIR -t $TEST_DIR -c $XTREEMFS_DIR/tests/test_config.py -p travis
+  - BUILD_CLIENT_TESTS=true make -j2
+  - ./tests/xtestenv --clean-test-dir -x $XTREEMFS_DIR -t $TEST_DIR -c $XTREEMFS_DIR/tests/test_config.py -p $TEST_SUITE
 
 after_failure:
   - JUNIT_RESULT=`./contrib/travis/parse_results.py $TEST_DIR/result.json 'JUnit tests'`

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,24 @@ TestSets = {
                 'dir_repl': False,
                 'snmp': False,
     },
+    'travis-junit' : {
+                'ssl': False,
+                'mrc_repl': False,
+                'dir_repl': False,
+                'snmp': False,
+    },
+    'travis-cpp' : {
+                'ssl': False,
+                'mrc_repl': False,
+                'dir_repl': False,
+                'snmp': False,
+    },
+    'travis-valgrind' : {
+                'ssl': False,
+                'mrc_repl': False,
+                'dir_repl': False,
+                'snmp': False,
+    },
 }
 
 VolumeConfigs = {
@@ -274,19 +292,19 @@ Tests = [
         'name': 'JUnit tests',
         'file': 'junit_tests.sh',
         'VolumeConfigs': [],
-        'TestSets': [ 'full', 'short', 'short-ssl', 'travis' ]
+        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-junit' ]
     },
     {
         'name': 'C++ Unit Tests',
         'file': 'cpp_unit_tests.sh',
         'VolumeConfigs': [],
-        'TestSets': [ 'full', 'short', 'short-ssl', 'travis' ]
+        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-cpp' ]
     },
     {
         'name': 'Valgrind memory-leak check for C++ Unit Tests',
         'file': 'cpp_unit_tests_valgrind.sh',
         'VolumeConfigs': [],
-        'TestSets': [ 'full', 'travis' ]
+        'TestSets': [ 'full', 'travis-valgrind' ]
     },
     {
         'name': 'mkfs-lsfs-rmfs.xtreemfs test',


### PR DESCRIPTION
Execute JUnit, C++ and C++ Valgrind tests in parallel to speed up travis builds.
