### PR TITLE
Making sure there are enough i-nodes, reduced number of files in benchmark

### DIFF
--- a/tests/cronjob/run_xtreemfs_tests.sh
+++ b/tests/cronjob/run_xtreemfs_tests.sh
@@ -143,7 +143,7 @@ make client_debug server hadoop-client &>$TEST_LOG
 if [ $? -ne 0 ]; then
   echo "FAILED: cannot make sources!" >> $TEST_LOG
   date >> $TEST_LOG
-  sendresult 1
+#  sendresult 1
   exit
 fi
 
@@ -152,4 +152,4 @@ fi
 cd $XTREEMFS_DIR/tests
 python -u xtestenv -t $TEST_DIR full &> $TEST_SUMMARY
 result=$?
-sendresult $result
+#sendresult $result

--- a/tests/cronjob/run_xtreemfs_tests.sh
+++ b/tests/cronjob/run_xtreemfs_tests.sh
@@ -103,7 +103,7 @@ fi
 
 # Cleanup test directory if disk is full
 min_free_space_mb=10000 # Remove all tests until enough space is available
-min_free_inodes=1200000
+min_free_inodes=2000000
 while true
 do
   # Enough free space?

--- a/tests/cronjob/run_xtreemfs_tests.sh
+++ b/tests/cronjob/run_xtreemfs_tests.sh
@@ -143,7 +143,7 @@ make client_debug server hadoop-client &>$TEST_LOG
 if [ $? -ne 0 ]; then
   echo "FAILED: cannot make sources!" >> $TEST_LOG
   date >> $TEST_LOG
-#  sendresult 1
+  sendresult 1
   exit
 fi
 
@@ -152,4 +152,4 @@ fi
 cd $XTREEMFS_DIR/tests
 python -u xtestenv -t $TEST_DIR full &> $TEST_SUMMARY
 result=$?
-#sendresult $result
+sendresult $result

--- a/tests/cronjob/run_xtreemfs_tests.sh
+++ b/tests/cronjob/run_xtreemfs_tests.sh
@@ -103,7 +103,7 @@ fi
 
 # Cleanup test directory if disk is full
 min_free_space_mb=10000 # Remove all tests until enough space is available
-min_free_inodes=1000
+min_free_inodes=1200000
 while true
 do
   # Enough free space?

--- a/tests/cronjob/run_xtreemfs_tests.sh
+++ b/tests/cronjob/run_xtreemfs_tests.sh
@@ -103,11 +103,13 @@ fi
 
 # Cleanup test directory if disk is full
 min_free_space_mb=10000 # Remove all tests until enough space is available
+min_free_inodes=1000
 while true
 do
   # Enough free space?
   free_space_mb=$(df -Pm $DIR_PREFIX | grep -v ^Filesystem | awk '{ print $4 }')
-  if [ $free_space_mb -ge $min_free_space_mb ]
+  free_inodes=$(df -i $DIR_PREFIX | grep -v ^Filesystem | awk '{ print $4 }')
+  if [ $free_space_mb -ge $min_free_space_mb ] && [ $free_inodes -ge $min_free_inodes ]
   then
     break
   fi

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,134 +153,134 @@ VolumeConfigs = {
 
 Tests = [
     # VOLUME TESTS
-#    {
-#        'name': 'Simple Metadata',
-#        'file': '01_simple_metadata.py',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache' ],
-#        'TestSets': [ 'short', 'full', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'Erichs dd write',
-#        'file': '02_erichs_ddwrite.py',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-#        'TestSets': [ 'full', 'short', 'short-ssl', 'packages-ssl' ]
-#    },
-#    {
-#        'name': 'Erichs data integrity test',
-#        'file': '03_erichs_data_integrity_test.py',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'Find Grep Tar',
-#        'file': '05_findgreptar.sh',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'fsx',
-#        'file': 'fsx.sh',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'bonnie',
-#        'file': '10_bonnie.py',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-#        # NOTE(mberlin): 2013/04: Disabled because it takes too long and was not helpful in finding problems so far.
-#        'TestSets': [ ]
-#    },
-#    {
-#        'name': 'IOZone diagnostic',
-#        'file': '11_iozone_diagnostic.py',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-#        'TestSets': [ 'full' ]
-#    },
-#    {
-#        'name': 'IOZone throughput',
-#        'file': '12_iozone_throughput.py',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-#        'TestSets': [ 'full' ]
-#    },
-#    {
-#        'name': 'DBench',
-#        'file': '13_dbench.py',
-#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache' ],
-#        'TestSets': [ 'full' ]
-#    },
-#    {
-#        'name': 'make xtreemfs',
-#        'file': '15_makextreemfs.py',
-#        'VolumeConfigs': [ 'regular', 'nomdcache' ],
-#        'TestSets': [ 'full' ]
-#    },
-#    {
-#        'name': 'IOZone multithread',
-#        'file': '16_iozone_multithread.py',
-#        'VolumeConfigs': [ 'regular' ],
-#        'TestSets': [ 'ssd' ]
-#    },
-#    {
-#        'name': 'bonnie multithread',
-#        'file': '17_bonnie_multithread.py',
-#        'VolumeConfigs': [ 'regular' ],
-#        'TestSets': [ 'ssd' ]
-#    },
-#    {
-#        'name': 'xtfs_cleanup test',
-#        'file': 'system_cleanup_test.sh',
-#        'VolumeConfigs': ['nomdcache'],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'snapshot test',
-#        'file': 'system_snap_test.sh',
-#        'VolumeConfigs': ['regular'],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'xattr test',
-#        'file': 'test_xattrs.sh',
-#        'VolumeConfigs': [ 'regular', 'nomdcache' ],
-#        'TestSets': [ 'full', 'short' ]
-#    },
-#    {
-#        'name': 'xtfs_scrub test',
-#        'file': 'system_scrub_test.sh',
-#        'VolumeConfigs': ['nomdcache'],
-#        #'TestSets': [ 'full', 'short', 'short-ssl' ]
-#        'TestSets': []
-#    },
-#    {
-#        'name': 'Add and delete replica manually (read-only replication)',
-#        'file': 'ronly_replication_add_delete_replica.sh',
-#        'VolumeConfigs': ['regular_two_osds'],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'POSIX Test Suite (root required)',
-#        'file': 'posix_test_suite.sh',
-#        'VolumeConfigs': ['regular', 'nomdcache'],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'hadoop test',
-#        'file': 'hadoop_test.sh',
-#        'VolumeConfigs': ['regular'],
-#        'TestSets': [ 'full' ] 
-#    },
-#    {
-#        'name': 'hadoop2 test',
-#        'file': 'hadoop2_test.sh',
-#        'VolumeConfigs': ['regular'],
-#        'TestSets': [ 'full' ] 
-#    },
-#    {
-#        'name': 'hadoop with ssl test',
-#        'file': 'hadoop_ssl_test.sh',
-#        'VolumeConfigs': ['regular_two_osds'],
-#        'TestSets': [ 'short-ssl' ]
-#    },
+    {
+        'name': 'Simple Metadata',
+        'file': '01_simple_metadata.py',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache' ],
+        'TestSets': [ 'short', 'full', 'short-ssl' ]
+    },
+    {
+        'name': 'Erichs dd write',
+        'file': '02_erichs_ddwrite.py',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+        'TestSets': [ 'full', 'short', 'short-ssl', 'packages-ssl' ]
+    },
+    {
+        'name': 'Erichs data integrity test',
+        'file': '03_erichs_data_integrity_test.py',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'Find Grep Tar',
+        'file': '05_findgreptar.sh',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'fsx',
+        'file': 'fsx.sh',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'bonnie',
+        'file': '10_bonnie.py',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+        # NOTE(mberlin): 2013/04: Disabled because it takes too long and was not helpful in finding problems so far.
+        'TestSets': [ ]
+    },
+    {
+        'name': 'IOZone diagnostic',
+        'file': '11_iozone_diagnostic.py',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+        'TestSets': [ 'full' ]
+    },
+    {
+        'name': 'IOZone throughput',
+        'file': '12_iozone_throughput.py',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+        'TestSets': [ 'full' ]
+    },
+    {
+        'name': 'DBench',
+        'file': '13_dbench.py',
+        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache' ],
+        'TestSets': [ 'full' ]
+    },
+    {
+        'name': 'make xtreemfs',
+        'file': '15_makextreemfs.py',
+        'VolumeConfigs': [ 'regular', 'nomdcache' ],
+        'TestSets': [ 'full' ]
+    },
+    {
+        'name': 'IOZone multithread',
+        'file': '16_iozone_multithread.py',
+        'VolumeConfigs': [ 'regular' ],
+        'TestSets': [ 'ssd' ]
+    },
+    {
+        'name': 'bonnie multithread',
+        'file': '17_bonnie_multithread.py',
+        'VolumeConfigs': [ 'regular' ],
+        'TestSets': [ 'ssd' ]
+    },
+    {
+        'name': 'xtfs_cleanup test',
+        'file': 'system_cleanup_test.sh',
+        'VolumeConfigs': ['nomdcache'],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'snapshot test',
+        'file': 'system_snap_test.sh',
+        'VolumeConfigs': ['regular'],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'xattr test',
+        'file': 'test_xattrs.sh',
+        'VolumeConfigs': [ 'regular', 'nomdcache' ],
+        'TestSets': [ 'full', 'short' ]
+    },
+    {
+        'name': 'xtfs_scrub test',
+        'file': 'system_scrub_test.sh',
+        'VolumeConfigs': ['nomdcache'],
+        #'TestSets': [ 'full', 'short', 'short-ssl' ]
+        'TestSets': []
+    },
+    {
+        'name': 'Add and delete replica manually (read-only replication)',
+        'file': 'ronly_replication_add_delete_replica.sh',
+        'VolumeConfigs': ['regular_two_osds'],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'POSIX Test Suite (root required)',
+        'file': 'posix_test_suite.sh',
+        'VolumeConfigs': ['regular', 'nomdcache'],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'hadoop test',
+        'file': 'hadoop_test.sh',
+        'VolumeConfigs': ['regular'],
+        'TestSets': [ 'full' ] 
+    },
+    {
+        'name': 'hadoop2 test',
+        'file': 'hadoop2_test.sh',
+        'VolumeConfigs': ['regular'],
+        'TestSets': [ 'full' ] 
+    },
+    {
+        'name': 'hadoop with ssl test',
+        'file': 'hadoop_ssl_test.sh',
+        'VolumeConfigs': ['regular_two_osds'],
+        'TestSets': [ 'short-ssl' ]
+    },
     {
         'name': 'xtfs_benchmark',
         'file': '14_xtfs_benchmark.sh',
@@ -288,40 +288,40 @@ Tests = [
         'TestSets': [ 'full' ]
     }
     # SYSTEM TESTS
-#    {
-#        'name': 'JUnit tests',
-#        'file': 'junit_tests.sh',
-#        'VolumeConfigs': [],
-#        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-junit' ]
-#    },
-#    {
-#        'name': 'C++ Unit Tests',
-#        'file': 'cpp_unit_tests.sh',
-#        'VolumeConfigs': [],
-#        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-cpp' ]
-#    },
-#    {
-#        'name': 'Valgrind memory-leak check for C++ Unit Tests',
-#        'file': 'cpp_unit_tests_valgrind.sh',
-#        'VolumeConfigs': [],
-#        'TestSets': [ 'full', 'travis-valgrind' ]
-#    },
-#    {
-#        'name': 'mkfs-lsfs-rmfs.xtreemfs test',
-#        'file': 'system_mkfs_lsfs_rmfs_test.sh',
-#        'VolumeConfigs': [],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'xtfs_mrcdbtool test',
-#        'file': 'system_mrcdbtool_test.sh',
-#        'VolumeConfigs': [],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    },
-#    {
-#        'name': 'xtfs_chstatus test',
-#        'file': 'system_chstatus_test.sh',
-#        'VolumeConfigs': [],
-#        'TestSets': [ 'full', 'short', 'short-ssl' ]
-#    }
+    {
+        'name': 'JUnit tests',
+        'file': 'junit_tests.sh',
+        'VolumeConfigs': [],
+        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-junit' ]
+    },
+    {
+        'name': 'C++ Unit Tests',
+        'file': 'cpp_unit_tests.sh',
+        'VolumeConfigs': [],
+        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-cpp' ]
+    },
+    {
+        'name': 'Valgrind memory-leak check for C++ Unit Tests',
+        'file': 'cpp_unit_tests_valgrind.sh',
+        'VolumeConfigs': [],
+        'TestSets': [ 'full', 'travis-valgrind' ]
+    },
+    {
+        'name': 'mkfs-lsfs-rmfs.xtreemfs test',
+        'file': 'system_mkfs_lsfs_rmfs_test.sh',
+        'VolumeConfigs': [],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'xtfs_mrcdbtool test',
+        'file': 'system_mrcdbtool_test.sh',
+        'VolumeConfigs': [],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'xtfs_chstatus test',
+        'file': 'system_chstatus_test.sh',
+        'VolumeConfigs': [],
+        'TestSets': [ 'full', 'short', 'short-ssl' ]
+    }
  ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -153,175 +153,175 @@ VolumeConfigs = {
 
 Tests = [
     # VOLUME TESTS
-    {
-        'name': 'Simple Metadata',
-        'file': '01_simple_metadata.py',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache' ],
-        'TestSets': [ 'short', 'full', 'short-ssl' ]
-    },
-    {
-        'name': 'Erichs dd write',
-        'file': '02_erichs_ddwrite.py',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-        'TestSets': [ 'full', 'short', 'short-ssl', 'packages-ssl' ]
-    },
-    {
-        'name': 'Erichs data integrity test',
-        'file': '03_erichs_data_integrity_test.py',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'Find Grep Tar',
-        'file': '05_findgreptar.sh',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'fsx',
-        'file': 'fsx.sh',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'bonnie',
-        'file': '10_bonnie.py',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-        # NOTE(mberlin): 2013/04: Disabled because it takes too long and was not helpful in finding problems so far.
-        'TestSets': [ ]
-    },
-    {
-        'name': 'IOZone diagnostic',
-        'file': '11_iozone_diagnostic.py',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-        'TestSets': [ 'full' ]
-    },
-    {
-        'name': 'IOZone throughput',
-        'file': '12_iozone_throughput.py',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
-        'TestSets': [ 'full' ]
-    },
-    {
-        'name': 'DBench',
-        'file': '13_dbench.py',
-        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache' ],
-        'TestSets': [ 'full' ]
-    },
-    {
-        'name': 'make xtreemfs',
-        'file': '15_makextreemfs.py',
-        'VolumeConfigs': [ 'regular', 'nomdcache' ],
-        'TestSets': [ 'full' ]
-    },
-    {
-        'name': 'IOZone multithread',
-        'file': '16_iozone_multithread.py',
-        'VolumeConfigs': [ 'regular' ],
-        'TestSets': [ 'ssd' ]
-    },
-    {
-        'name': 'bonnie multithread',
-        'file': '17_bonnie_multithread.py',
-        'VolumeConfigs': [ 'regular' ],
-        'TestSets': [ 'ssd' ]
-    },
-    {
-        'name': 'xtfs_cleanup test',
-        'file': 'system_cleanup_test.sh',
-        'VolumeConfigs': ['nomdcache'],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'snapshot test',
-        'file': 'system_snap_test.sh',
-        'VolumeConfigs': ['regular'],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'xattr test',
-        'file': 'test_xattrs.sh',
-        'VolumeConfigs': [ 'regular', 'nomdcache' ],
-        'TestSets': [ 'full', 'short' ]
-    },
-    {
-        'name': 'xtfs_scrub test',
-        'file': 'system_scrub_test.sh',
-        'VolumeConfigs': ['nomdcache'],
-        #'TestSets': [ 'full', 'short', 'short-ssl' ]
-        'TestSets': []
-    },
-    {
-        'name': 'Add and delete replica manually (read-only replication)',
-        'file': 'ronly_replication_add_delete_replica.sh',
-        'VolumeConfigs': ['regular_two_osds'],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'POSIX Test Suite (root required)',
-        'file': 'posix_test_suite.sh',
-        'VolumeConfigs': ['regular', 'nomdcache'],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'hadoop test',
-        'file': 'hadoop_test.sh',
-        'VolumeConfigs': ['regular'],
-        'TestSets': [ 'full' ] 
-    },
-    {
-        'name': 'hadoop2 test',
-        'file': 'hadoop2_test.sh',
-        'VolumeConfigs': ['regular'],
-        'TestSets': [ 'full' ] 
-    },
-    {
-        'name': 'hadoop with ssl test',
-        'file': 'hadoop_ssl_test.sh',
-        'VolumeConfigs': ['regular_two_osds'],
-        'TestSets': [ 'short-ssl' ]
-    },
+#    {
+#        'name': 'Simple Metadata',
+#        'file': '01_simple_metadata.py',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache' ],
+#        'TestSets': [ 'short', 'full', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'Erichs dd write',
+#        'file': '02_erichs_ddwrite.py',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+#        'TestSets': [ 'full', 'short', 'short-ssl', 'packages-ssl' ]
+#    },
+#    {
+#        'name': 'Erichs data integrity test',
+#        'file': '03_erichs_data_integrity_test.py',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'Find Grep Tar',
+#        'file': '05_findgreptar.sh',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'fsx',
+#        'file': 'fsx.sh',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'bonnie',
+#        'file': '10_bonnie.py',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+#        # NOTE(mberlin): 2013/04: Disabled because it takes too long and was not helpful in finding problems so far.
+#        'TestSets': [ ]
+#    },
+#    {
+#        'name': 'IOZone diagnostic',
+#        'file': '11_iozone_diagnostic.py',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+#        'TestSets': [ 'full' ]
+#    },
+#    {
+#        'name': 'IOZone throughput',
+#        'file': '12_iozone_throughput.py',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites' ],
+#        'TestSets': [ 'full' ]
+#    },
+#    {
+#        'name': 'DBench',
+#        'file': '13_dbench.py',
+#        'VolumeConfigs': [ 'regular', 'directio', 'striped2', 'nomdcache' ],
+#        'TestSets': [ 'full' ]
+#    },
+#    {
+#        'name': 'make xtreemfs',
+#        'file': '15_makextreemfs.py',
+#        'VolumeConfigs': [ 'regular', 'nomdcache' ],
+#        'TestSets': [ 'full' ]
+#    },
+#    {
+#        'name': 'IOZone multithread',
+#        'file': '16_iozone_multithread.py',
+#        'VolumeConfigs': [ 'regular' ],
+#        'TestSets': [ 'ssd' ]
+#    },
+#    {
+#        'name': 'bonnie multithread',
+#        'file': '17_bonnie_multithread.py',
+#        'VolumeConfigs': [ 'regular' ],
+#        'TestSets': [ 'ssd' ]
+#    },
+#    {
+#        'name': 'xtfs_cleanup test',
+#        'file': 'system_cleanup_test.sh',
+#        'VolumeConfigs': ['nomdcache'],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'snapshot test',
+#        'file': 'system_snap_test.sh',
+#        'VolumeConfigs': ['regular'],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'xattr test',
+#        'file': 'test_xattrs.sh',
+#        'VolumeConfigs': [ 'regular', 'nomdcache' ],
+#        'TestSets': [ 'full', 'short' ]
+#    },
+#    {
+#        'name': 'xtfs_scrub test',
+#        'file': 'system_scrub_test.sh',
+#        'VolumeConfigs': ['nomdcache'],
+#        #'TestSets': [ 'full', 'short', 'short-ssl' ]
+#        'TestSets': []
+#    },
+#    {
+#        'name': 'Add and delete replica manually (read-only replication)',
+#        'file': 'ronly_replication_add_delete_replica.sh',
+#        'VolumeConfigs': ['regular_two_osds'],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'POSIX Test Suite (root required)',
+#        'file': 'posix_test_suite.sh',
+#        'VolumeConfigs': ['regular', 'nomdcache'],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'hadoop test',
+#        'file': 'hadoop_test.sh',
+#        'VolumeConfigs': ['regular'],
+#        'TestSets': [ 'full' ] 
+#    },
+#    {
+#        'name': 'hadoop2 test',
+#        'file': 'hadoop2_test.sh',
+#        'VolumeConfigs': ['regular'],
+#        'TestSets': [ 'full' ] 
+#    },
+#    {
+#        'name': 'hadoop with ssl test',
+#        'file': 'hadoop_ssl_test.sh',
+#        'VolumeConfigs': ['regular_two_osds'],
+#        'TestSets': [ 'short-ssl' ]
+#    },
     {
         'name': 'xtfs_benchmark',
         'file': '14_xtfs_benchmark.sh',
         'VolumeConfigs': [ 'regular', 'regular_two_osds', 'nomdcache', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites'],
         'TestSets': [ 'full' ]
-    },
-    # SYSTEM TESTS
-    {
-        'name': 'JUnit tests',
-        'file': 'junit_tests.sh',
-        'VolumeConfigs': [],
-        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-junit' ]
-    },
-    {
-        'name': 'C++ Unit Tests',
-        'file': 'cpp_unit_tests.sh',
-        'VolumeConfigs': [],
-        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-cpp' ]
-    },
-    {
-        'name': 'Valgrind memory-leak check for C++ Unit Tests',
-        'file': 'cpp_unit_tests_valgrind.sh',
-        'VolumeConfigs': [],
-        'TestSets': [ 'full', 'travis-valgrind' ]
-    },
-    {
-        'name': 'mkfs-lsfs-rmfs.xtreemfs test',
-        'file': 'system_mkfs_lsfs_rmfs_test.sh',
-        'VolumeConfigs': [],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'xtfs_mrcdbtool test',
-        'file': 'system_mrcdbtool_test.sh',
-        'VolumeConfigs': [],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
-    },
-    {
-        'name': 'xtfs_chstatus test',
-        'file': 'system_chstatus_test.sh',
-        'VolumeConfigs': [],
-        'TestSets': [ 'full', 'short', 'short-ssl' ]
     }
+    # SYSTEM TESTS
+#    {
+#        'name': 'JUnit tests',
+#        'file': 'junit_tests.sh',
+#        'VolumeConfigs': [],
+#        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-junit' ]
+#    },
+#    {
+#        'name': 'C++ Unit Tests',
+#        'file': 'cpp_unit_tests.sh',
+#        'VolumeConfigs': [],
+#        'TestSets': [ 'full', 'short', 'short-ssl', 'travis-cpp' ]
+#    },
+#    {
+#        'name': 'Valgrind memory-leak check for C++ Unit Tests',
+#        'file': 'cpp_unit_tests_valgrind.sh',
+#        'VolumeConfigs': [],
+#        'TestSets': [ 'full', 'travis-valgrind' ]
+#    },
+#    {
+#        'name': 'mkfs-lsfs-rmfs.xtreemfs test',
+#        'file': 'system_mkfs_lsfs_rmfs_test.sh',
+#        'VolumeConfigs': [],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'xtfs_mrcdbtool test',
+#        'file': 'system_mrcdbtool_test.sh',
+#        'VolumeConfigs': [],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    },
+#    {
+#        'name': 'xtfs_chstatus test',
+#        'file': 'system_chstatus_test.sh',
+#        'VolumeConfigs': [],
+#        'TestSets': [ 'full', 'short', 'short-ssl' ]
+#    }
  ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -286,7 +286,7 @@ Tests = [
         'file': '14_xtfs_benchmark.sh',
         'VolumeConfigs': [ 'regular', 'regular_two_osds', 'nomdcache', 'directio', 'striped2', 'replicated_wqrq', 'replicated_wqrq_asyncwrites'],
         'TestSets': [ 'full' ]
-    }
+    },
     # SYSTEM TESTS
     {
         'name': 'JUnit tests',

--- a/tests/test_scripts/14_xtfs_benchmark.sh
+++ b/tests/test_scripts/14_xtfs_benchmark.sh
@@ -9,9 +9,9 @@ TEST_DIR=$4
 VOLUME="$(basename $(dirname $(pwd)))"
 
 exec $JAVA_HOME/bin/java -ea -cp $XTREEMFS/java/servers/dist/XtreemFS.jar:$XTREEMFS/java/foundation/dist/Foundation.jar:$XTREEMFS/java/lib/*:/usr/share/java/XtreemFS.jar:/usr/share/java/protobuf-java-2.5.0.jar:/usr/share/java/Foundation.jar:. \
-  org.xtreemfs.utils.xtfs_benchmark.xtfs_benchmark -sw -sr -rw -rr -fw -fr --stripe-size 128K --stripe-width 1 -ssize 500m -rsize 100m --file-size 4K --basefile-size 500m --dir-addresses $DIR_SERVER --user $USER --group $USER $VOLUME
+  org.xtreemfs.utils.xtfs_benchmark.xtfs_benchmark -sw -sr -rw -rr -fw -fr --stripe-size 128K --stripe-width 1 -ssize 500m -rsize 100m --file-size 64K --basefile-size 500m --dir-addresses $DIR_SERVER --user $USER --group $USER $VOLUME
 
 # minimal version for testing
 # exec $JAVA_HOME/bin/java -ea -cp $XTREEMFS/java/servers/dist/XtreemFS.jar:$XTREEMFS/java/foundation/dist/Foundation.jar:$XTREEMFS/java/lib/*:/usr/share/java/XtreemFS.jar:/usr/share/java/protobuf-java-2.5.0.jar:/usr/share/java/Foundation.jar:. \
-#   org.xtreemfs.utils.xtfs_benchmark.xtfs_benchmark -sw -sr -rw -rr -fw -fr -t 1 --stripe-size 128K --stripe-width 1 -ssize 10m -rsize 1m --file-size 4K --basefile-size 100m --dir-address $DIR_SERVER $VOLUME
+#   org.xtreemfs.utils.xtfs_benchmark.xtfs_benchmark -sw -sr -rw -rr -fw -fr -t 1 --stripe-size 128K --stripe-width 1 -ssize 10m -rsize 1m --file-size 64K --basefile-size 100m --dir-address $DIR_SERVER $VOLUME
 


### PR DESCRIPTION
Because the file based benchmarks produce a large number of files, it is both necessary to:
- Make sure that there is not only enough space available, but also sufficiently many i-nodes and
- Increase the file size in the file based benchmarks to reduce the number of files produced.