### PR TITLE
Hopefully fixing the 'Address already in use' exception in JUnit

### DIFF
--- a/tests/test_scripts/junit_tests.sh
+++ b/tests/test_scripts/junit_tests.sh
@@ -45,9 +45,9 @@ function get_xtreemfs_ports() {
 function wait_for_time_wait_ports() {
   ports_regex=$(get_xtreemfs_ports)
   
-  while [ -n "$(netstat -n -l -t | grep -E "$ports_regex")" ]
+  while [ -n "$(netstat -n -a -t | grep -E "$ports_regex")" ]
   do
-    sleep 1
+    sleep 60
   done
 }
 


### PR DESCRIPTION
The -l option causes netstat to print only connections in LISTEN state. Changed that to -a to include connections in TIME_WAIT state as well. Because a connection may remain in that state for 4 minutes (as some discussions suggest), a sleep of 60 seconds seems more appropriate as well.