### PR TITLE
Waiting for ports to become free on JUnit test failure

### DIFF
--- a/tests/test_scripts/junit_tests.sh
+++ b/tests/test_scripts/junit_tests.sh
@@ -119,7 +119,7 @@ while read LINE; do
     fi
       
     # If the test failed before, try and see if waiting for all ports to become free solves the problem.
-    if [ $i -gt 1 ]
+    if [ $i -gt 1 ]; then
       echo -n "Test try $i failed, waiting for ports to become free ... "
       before_wait_ports=$(date +%s)
       wait_for_time_wait_ports

--- a/tests/test_scripts/junit_tests.sh
+++ b/tests/test_scripts/junit_tests.sh
@@ -47,6 +47,7 @@ function wait_for_time_wait_ports() {
   
   while [ -n "$(netstat -n -a -t | grep -E "$ports_regex")" ]
   do
+    echo "Port is still in use, waiting 60 seconds"
     sleep 60
   done
 }

--- a/tests/test_scripts/junit_tests.sh
+++ b/tests/test_scripts/junit_tests.sh
@@ -108,23 +108,21 @@ while read LINE; do
     i=`expr $i + 1`
   
     if [ "$RESULT" -ne "0" ]; then
-      echo "FAILURE"
+      echo -n "FAILURE, waiting for ports to become free before retrying ... "
+
       # Log netstat output to debug "address already in use" problems.
       temp_file="$(mktemp netstat.XXXXXX)"
       netstat -n -t -a &> "$temp_file.all"
       netstat -n -t -l &> "$temp_file.listen"
       netstat -n -t -a -o &> "$temp_file.all+timer"
-    else
-      echo "ok"
-    fi
-      
-    # If the test failed before, try and see if waiting for all ports to become free solves the problem.
-    if [ $i -gt 1 ]; then
-      echo -n "Test try $i failed, waiting for ports to become free ... "
+
+      # Wait for all ports to become free before retrying in case the cause was the "address already in use" problem.
       before_wait_ports=$(date +%s)
       wait_for_time_wait_ports
       after_wait_ports=$(date +%s)
-      echo " done after $((after_wait_ports - before_wait_ports))s."
+      echo " ports free after $((after_wait_ports - before_wait_ports))s."
+    else
+      echo "ok"
     fi
   done
 

--- a/tests/test_scripts/junit_tests.sh
+++ b/tests/test_scripts/junit_tests.sh
@@ -47,8 +47,7 @@ function wait_for_time_wait_ports() {
   
   while [ -n "$(netstat -n -a -t | grep -E "$ports_regex")" ]
   do
-    echo "Port is still in use, waiting 60 seconds"
-    sleep 60
+    sleep 1
   done
 }
 

--- a/tests/test_scripts/junit_tests.sh
+++ b/tests/test_scripts/junit_tests.sh
@@ -108,17 +108,20 @@ while read LINE; do
     i=`expr $i + 1`
   
     if [ "$RESULT" -ne "0" ]; then
-      echo "FAILURE"
+      echo -n "FAILURE"
       # Log netstat output to debug "address already in use" problems.
       temp_file="$(mktemp netstat.XXXXXX)"
       netstat -n -t -a &> "$temp_file.all"
       netstat -n -t -l &> "$temp_file.listen"
       netstat -n -t -a -o &> "$temp_file.all+timer"
     else
-      echo "ok"
+      echo -n "ok"
     fi
       
+    before_wait_ports=$(date +%s)
     wait_for_time_wait_ports
+    after_wait_ports=$(date +%s)
+    echo " (Waited $((after_wait_ports - before_wait_ports))s for ports)"
   done
 
   if [ "$RESULT" -ne "0" ]; then

--- a/tests/test_scripts/junit_tests.sh
+++ b/tests/test_scripts/junit_tests.sh
@@ -108,20 +108,24 @@ while read LINE; do
     i=`expr $i + 1`
   
     if [ "$RESULT" -ne "0" ]; then
-      echo -n "FAILURE"
+      echo "FAILURE"
       # Log netstat output to debug "address already in use" problems.
       temp_file="$(mktemp netstat.XXXXXX)"
       netstat -n -t -a &> "$temp_file.all"
       netstat -n -t -l &> "$temp_file.listen"
       netstat -n -t -a -o &> "$temp_file.all+timer"
     else
-      echo -n "ok"
+      echo "ok"
     fi
       
-    before_wait_ports=$(date +%s)
-    wait_for_time_wait_ports
-    after_wait_ports=$(date +%s)
-    echo " (Waited $((after_wait_ports - before_wait_ports))s for ports)"
+    # If the test failed before, try and see if waiting for all ports to become free solves the problem.
+    if [ $i -gt 1 ]
+      echo -n "Test try $i failed, waiting for ports to become free ... "
+      before_wait_ports=$(date +%s)
+      wait_for_time_wait_ports
+      after_wait_ports=$(date +%s)
+      echo " done after $((after_wait_ports - before_wait_ports))s."
+    fi
   done
 
   if [ "$RESULT" -ne "0" ]; then

--- a/tests/test_scripts/junit_tests.sh
+++ b/tests/test_scripts/junit_tests.sh
@@ -45,9 +45,9 @@ function get_xtreemfs_ports() {
 function wait_for_time_wait_ports() {
   ports_regex=$(get_xtreemfs_ports)
   
-  while [ -n "$(netstat -n -l -t | grep -E "$ports_regex")" ]
+  while [ -n "$(netstat -n -a -t | grep -E "$ports_regex")" ]
   do
-    sleep 1
+    sleep 60
   done
 }
 


### PR DESCRIPTION
netstat -a instead of -l in order to get TIME_WAIT connections as well (instead of LISTEN only). Only wait in case of a test failure to avoid prolonging test execution unnecessarily.