### PR TITLE
Separate .travis.yml file for master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: java
 jdk: openjdk6
 
 env:
-  global:
-    # encrypted COVERITY_SCAN_TOKEN
-    - secure: "WkngHI6zO+6m8ZNqrbFZN+V8xCUxXVUMzLGBcOMa2/iiSDGxnRRpGU2jH+4Uf4ChCE4dXLrTXvs4vDjUT7aZ9KVFzcTo4HYejdLeMayFPLeztSYdFUG7EYtambZlh1Ldp67+ZBXLJ152iTWvCm5t/JXs3tA+Q5puZ24OO+U5xAE="
   matrix:
     # test suites to run in parallel
     - TEST_SUITE=travis-junit
@@ -21,10 +18,8 @@ before_script:
   - XTREEMFS_DIR=`pwd`
 
 script:
-  - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then
-    BUILD_CLIENT_TESTS=true make -j2;
-    ./tests/xtestenv --clean-test-dir -x $XTREEMFS_DIR -t $TEST_DIR -c $XTREEMFS_DIR/tests/test_config.py -p $TEST_SUITE;
-    fi
+  - BUILD_CLIENT_TESTS=true make -j2
+  - ./tests/xtestenv --clean-test-dir -x $XTREEMFS_DIR -t $TEST_DIR -c $XTREEMFS_DIR/tests/test_config.py -p $TEST_SUITE
 
 after_failure:
   - JUNIT_RESULT=`./contrib/travis/parse_results.py $TEST_DIR/result.json 'JUnit tests'`
@@ -33,13 +28,3 @@ after_failure:
   - if [[ $JUNIT_RESULT = "false" ]]; then cat $TEST_DIR/log/junit.log; fi
   - if [[ $CPP_RESULT = "false" ]]; then cat cpp/build/Testing/Temporary/LastTest.log; fi
   - if [[ $VALGRIND_RESULT = "false" ]]; then cat $TEST_DIR/log/valgrind.log; fi
-
-addons:
-  coverity_scan:
-    project:
-      name: xtreemfs/xtreemfs
-      description: Distributed Fault-Tolerant File System http://www.xtreemfs.org
-    notification_email: xtreemfs-test@googlegroups.com
-    build_command_prepend: make distclean
-    build_command: make
-    branch_pattern: coverity_scan


### PR DESCRIPTION
Since the coverity_scan branch will contain its own .travis.yml file, there is no need to specify the coverity_scan addon in the master branch's .travis.yml file.