### PR TITLE
Run Coverity Scan each night with the other tests

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -329,5 +329,11 @@ Tests = [
         'file': 'system_chstatus_test.sh',
         'VolumeConfigs': [],
         'TestSets': [ 'full', 'short', 'short-ssl' ]
+    },
+    {
+        'name': 'Coverity Scan Test',
+        'file': 'coverity_scan_test.sh',
+        'VolumeConfigs': [],
+        'TestSets': [ 'full' ]
     }
  ]

--- a/tests/test_scripts/coverity_scan_test.sh
+++ b/tests/test_scripts/coverity_scan_test.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright (c) 2015 by Robert Schmidtke, Zuse Institute Berlin
+#
+# Licensed under the BSD License, see LICENSE file for details.
+
+# This test executes the coverity code scan by pushing the current
+# master branch to the coverity_scan branch.
+
+set -e
+
+XTREEMFS_DIR="$1"
+
+cd "$XTREEMFS_DIR"
+
+git checkout coverity_scan
+
+# This script exists in coverity_scan only and takes care of
+# not overwriting .travis.yml when mergin from master.
+./merge.sh
+
+# Trigger the coverity scan through Travis CI.
+git push origin coverity_scan
+
+git checkout master

--- a/tests/test_scripts/coverity_scan_test.sh
+++ b/tests/test_scripts/coverity_scan_test.sh
@@ -16,7 +16,7 @@ cd "$XTREEMFS_DIR"
 git checkout coverity_scan
 
 # This script exists in coverity_scan only and takes care of
-# not overwriting .travis.yml when mergin from master.
+# not overwriting .travis.yml when merging from master.
 ./merge.sh
 
 # Trigger the coverity scan through Travis CI.


### PR DESCRIPTION
This PR adds the Coverity Scan to the set of tests that is run each night. The current master is merged into coverity_scan and pushed to GitHub. Travis CI will pick up on the coverity_branch and run the Coverity Scan.