### PR TITLE
Use SSH clone in test so subsequent pushes wont ask for username/password

### DIFF
--- a/tests/cronjob/run_xtreemfs_tests.sh
+++ b/tests/cronjob/run_xtreemfs_tests.sh
@@ -130,9 +130,9 @@ mkdir -p $DIR_PREFIX
 mkdir -p $XTREEMFS_DIR
 mkdir -p $TEST_DIR
 
-# Check out
+# Check out using SSH for passwordless push using deploy keys.
 cd $XTREEMFS_DIR
-git clone https://github.com/xtreemfs/xtreemfs.git . &> $TEST_LOG
+git clone git@github.com:xtreemfs/xtreemfs.git . &> $TEST_LOG
 
 # Compile
 # 2012-11-02(mberlin): Try to disable optimizations in client compilation.


### PR DESCRIPTION
The Coverity Scan test requires push access to the xtreemfs repository. The public key of the user on the server that the nightly tests run on has been added as a deploy key. SSH clones create a remote URL with SSH so pushes to origin won't ask for username/password. This allows for non-interactive nightly Coverity Scan tests.