### PR TITLE
Inherit groupId if setgid is set. 

### DIFF
--- a/java/servers/src/org/xtreemfs/mrc/operations/CreateDirOperation.java
+++ b/java/servers/src/org/xtreemfs/mrc/operations/CreateDirOperation.java
@@ -16,9 +16,10 @@ import org.xtreemfs.mrc.UserException;
 import org.xtreemfs.mrc.ac.FileAccessManager;
 import org.xtreemfs.mrc.database.AtomicDBUpdate;
 import org.xtreemfs.mrc.database.DatabaseException;
+import org.xtreemfs.mrc.database.DatabaseException.ExceptionType;
 import org.xtreemfs.mrc.database.StorageManager;
 import org.xtreemfs.mrc.database.VolumeManager;
-import org.xtreemfs.mrc.database.DatabaseException.ExceptionType;
+import org.xtreemfs.mrc.metadata.FileMetadata;
 import org.xtreemfs.mrc.utils.MRCHelper;
 import org.xtreemfs.mrc.utils.Path;
 import org.xtreemfs.mrc.utils.PathResolver;
@@ -55,7 +56,8 @@ public class CreateDirOperation extends MRCOperation {
         final PathResolver res = new PathResolver(sMan, p);
         
         // check if dir == volume
-        if (res.getParentDir() == null)
+        final FileMetadata parent = res.getParentDir();
+        if (parent == null)
             throw new UserException(POSIXErrno.POSIX_ERROR_EEXIST, "file or directory '" + res.getFileName()
                 + "' exists already");
         
@@ -64,12 +66,19 @@ public class CreateDirOperation extends MRCOperation {
                 .getDetails().groupIds);
         
         // check whether the parent directory grants write access
-        faMan.checkPermission(FileAccessManager.O_WRONLY, sMan, res.getParentDir(), res.getParentsParentId(),
+        faMan.checkPermission(FileAccessManager.O_WRONLY, sMan, parent, parent.getId(),
             rq.getDetails().userId, rq.getDetails().superUser, rq.getDetails().groupIds);
         
         // check whether the file/directory exists already
         res.checkIfFileExistsAlready();
         
+        // Inherit the groupId if the setgid bit is set
+        String groupId = rq.getDetails().groupIds.get(0);
+        int parentMode = faMan.getPosixAccessMode(sMan, parent, rq.getDetails().userId, rq.getDetails().groupIds);
+        if ((parentMode & 02000) > 0) {
+            groupId = parent.getOwningGroupId();
+        }
+
         // prepare directory creation in database
         AtomicDBUpdate update = sMan.createAtomicDBUpdate(master, rq);
         
@@ -80,14 +89,14 @@ public class CreateDirOperation extends MRCOperation {
         int time = (int) (TimeSync.getGlobalTime() / 1000);
         
         // create the metadata object
-        sMan.createDir(fileId, res.getParentDirId(), res.getFileName(), time, time, time,
-            rq.getDetails().userId, rq.getDetails().groupIds.get(0), rqArgs.getMode(), 0, update);
+        sMan.createDir(fileId, parent.getId(), res.getFileName(), time, time, time, rq.getDetails().userId, groupId,
+                rqArgs.getMode(), 0, update);
         
         // set the file ID as the last one
         sMan.setLastFileId(fileId, update);
         
         // update POSIX timestamps of parent directory
-        MRCHelper.updateFileTimes(res.getParentsParentId(), res.getParentDir(), false, true, true, sMan,
+        MRCHelper.updateFileTimes(parent.getId(), parent, false, true, true, sMan,
             time, update);
         
         // set the response

--- a/java/servers/src/org/xtreemfs/mrc/operations/OpenOperation.java
+++ b/java/servers/src/org/xtreemfs/mrc/operations/OpenOperation.java
@@ -146,10 +146,18 @@ public class OpenOperation extends MRCOperation {
                     throw new UserException(POSIXErrno.POSIX_ERROR_EIO, "FIFOs not supported");
                 }
                 
+                // Inherit the groupId if the setgid bit is set
+                String groupId = rq.getDetails().groupIds.get(0);
+                int parentMode = faMan.getPosixAccessMode(sMan, res.getParentDir(), rq.getDetails().userId,
+                        rq.getDetails().groupIds);
+                if ((parentMode & 02000) > 0) {
+                    groupId = res.getParentDir().getOwningGroupId();
+                }
+
                 // create the metadata object
-                file = sMan.createFile(fileId, res.getParentDirId(), res.getFileName(), time, time, time, rq
-                        .getDetails().userId, rq.getDetails().groupIds.get(0), rqArgs.getMode(), rqArgs
-                        .getAttributes(), 0, false, 0, 0, update);
+                file = sMan.createFile(fileId, res.getParentDirId(), res.getFileName(), time, time, time,
+                        rq.getDetails().userId, groupId, rqArgs.getMode(), rqArgs.getAttributes(), 0, false, 0, 0,
+                        update);
                 
                 // set the file ID as the last one
                 sMan.setLastFileId(fileId, update);

--- a/java/servers/test/org/xtreemfs/common/libxtreemfs/VolumeTest.java
+++ b/java/servers/test/org/xtreemfs/common/libxtreemfs/VolumeTest.java
@@ -6,6 +6,17 @@
  */
 package org.xtreemfs.common.libxtreemfs;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -30,18 +41,25 @@ import org.xtreemfs.mrc.utils.MRCHelper.SysAttrs;
 import org.xtreemfs.osd.OSD;
 import org.xtreemfs.osd.OSDConfig;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes;
-import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.*;
-import org.xtreemfs.pbrpc.generatedinterfaces.MRC.*;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.AccessControlPolicyType;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.KeyValuePair;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.Replica;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.SYSTEM_V_FCNTL;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.StripingPolicy;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.StripingPolicyType;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.VivaldiCoordinates;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.DirectoryEntries;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.Setattrs;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.Stat;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.StatVFS;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.XATTR_FLAGS;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.getattrResponse;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.openResponse;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.statvfsRequest;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRCServiceClient;
 import org.xtreemfs.test.SetupUtils;
 import org.xtreemfs.test.TestEnvironment;
 import org.xtreemfs.test.TestHelper;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.*;
 
 public class VolumeTest {
     @Rule
@@ -986,5 +1004,40 @@ public class VolumeTest {
                 assertTrue(false);
             }
         }
+    }
+
+    @Test
+    public void testSetgid() throws Exception {
+        VOLUME_NAME = "testSetgid";
+        client.createVolume(mrcAddress, auth, userCredentials, VOLUME_NAME);
+        Volume volume = client.openVolume(VOLUME_NAME, null, options);
+
+        volume.createDirectory(userCredentials, "/DIR1", 0777);
+
+        Stat stat;
+        stat = volume.getAttr(userCredentials, "/DIR1");
+
+        int mode = stat.getMode() | 02000;
+        stat = stat.toBuilder().setGroupId("foobar").setMode(mode).build();
+
+        UserCredentials rootCreds = userCredentials.toBuilder().setUsername("root").setGroups(0, "root").build();
+        volume.setAttr(rootCreds, "/DIR1", stat, Setattrs.SETATTR_MODE.getNumber() | Setattrs.SETATTR_GID.getNumber());
+
+        stat = volume.getAttr(userCredentials, "/DIR1");
+        assertEquals(mode, stat.getMode());
+        assertEquals("foobar", stat.getGroupId());
+
+        volume.createDirectory(userCredentials, "/DIR1/DIR2", 0777);
+        stat = volume.getAttr(userCredentials, "/DIR1/DIR2");
+        assertEquals("foobar", stat.getGroupId());
+
+        FileHandle fh = volume.openFile(userCredentials, "/DIR1/FILE1",
+                SYSTEM_V_FCNTL.SYSTEM_V_FCNTL_H_O_CREAT.getNumber());
+        fh.close();
+
+        stat = volume.getAttr(userCredentials, "/DIR1/FILE1");
+        assertEquals("foobar", stat.getGroupId());
+
+        volume.close();
     }
 }


### PR DESCRIPTION
It is common to most POSIX filesystems to inherit the group id if the setgid bit is set on a directory [0].
This commit introduces group inheritance to the MRC and fixes issue #385. 
Although i am not sure if this is part of the POSIX standard it could be useful to implement it in regard to compatibility. 


[0] https://www.gnu.org/software/coreutils/manual/html_node/Directory-Setuid-and-Setgid.html