### PR TITLE
 Add separate config for manual xtestenvs which does not require allow_other.

### DIFF
--- a/tests/manual_config.py
+++ b/tests/manual_config.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2009-2011 by Bjoern Kolbeck, Zuse Institute Berlin
+# Licensed under the BSD License, see LICENSE file for details.
+
+TestSets = {
+    # This configuration is used for manual test environment set-ups (option -e).
+    'manual' : {
+                'ssl': False,
+                'mrc_repl': False,
+                'dir_repl': False,
+                'snmp': True,
+    },
+    # This configuration is used for manual test environment set-ups with SSL enabled (option -f).
+    'manual-ssl' : {
+                'ssl': True,
+                'mrc_repl': False,
+                'dir_repl': False,
+                'snmp': True,
+    },
+}
+
+VolumeConfigs = {
+    'regular' : {
+                    'stripe_size': 128,
+                    'stripe_width': 1,
+                    'rwr_factor': 0,
+                    'ronly_factor': 0,
+                    'min_osds': 3,
+                    'mount_options': [ '-ouser_xattr' ],
+                    'mkfs_options':  [ '--max-tries=10' ]
+                },
+    'nomdcache' : {
+                    'stripe_size': 128,
+                    'stripe_width': 1,
+                    'rwr_factor': 0,
+                    'ronly_factor': 0,
+                    'mount_options': [ '--metadata-cache-size=0', '-ouser_xattr' ],
+                    'mkfs_options':  [ '--max-tries=10' ]
+                },
+    'directio' : {
+                    'stripe_size': 128,
+                    'stripe_width': 1,
+                    'rwr_factor': 0,
+                    'ronly_factor': 0,
+                    'mount_options': [ '-odirect_io' ],
+                    'mkfs_options':  [ '--max-tries=10']
+                },
+    'striped2' : {
+                    'stripe_size': 128,
+                    'stripe_width': 2,
+                    'rwr_factor': 0,
+                    'ronly_factor': 0,
+                    'mount_options': [ ],
+                    'mkfs_options':  [ '--max-tries=10']
+                },
+    'replicated_wqrq' : {
+                    'stripe_size': 128,
+                    'stripe_width': 1,
+                    'rwr_factor': 3,
+                    'ronly_factor': 0,
+                    'mount_options': [ ],
+                    'mkfs_options':  [ '--max-tries=10']
+                },
+    'replicated_wqrq_asyncwrites' : {
+                    'stripe_size': 128,
+                    'stripe_width': 1,
+                    'rwr_factor': 3,
+                    'ronly_factor': 0,
+                    'mount_options': [ '--enable-async-writes' ],
+                    'mkfs_options':  [ '--max-tries=10']
+                },
+    'replicated_war1' : {
+                    'stripe_size': 128,
+                    'stripe_width': 1,
+                    'rwr_policy': 'all',
+                    'rwr_factor': 2,
+                    'ronly_factor': 0,
+                    'mount_options': [ '--max-tries=240', '--max-read-tries=240', '--max-write-tries=240' ],
+                    'mkfs_options':  [ '--max-tries=10']
+                },
+}
+
+Tests = [ ]

--- a/tests/xtestenv
+++ b/tests/xtestenv
@@ -483,7 +483,7 @@ if __name__ == "__main__":
     option_parser.add_option( "-t", "--test-dir", action="store", dest="test_dir", default='/tmp/xtreemfs_xtestenv/', help="Directory where all temporary test files will be stored.")
     option_parser.add_option( "-v", "--volume", action="store", dest="volume", help="Test a specific volume config.")
     option_parser.add_option( "--clean-test-dir", action="store_true", dest="clean_test_dir", help="Remove content of --test-dir before executing the test")
-    option_parser.add_option( "-c", "--config-file-path", action="store", dest="config_file_path", default='test_config.py')
+    option_parser.add_option( "-c", "--config-file-path", action="store", dest="config_file_path")
     option_parser.add_option( "-d", "--debug-level", action="store", dest="debug_level", default=6 )
     option_parser.add_option( "-x", "--xtreemfs-base-dir", action="store", dest="xtreemfs_dir", default=xtreemfs_dir)
     option_parser.add_option( "-e", "--start-test-env", action="store_true", dest="start_test_env")
@@ -495,6 +495,12 @@ if __name__ == "__main__":
         option_parser.print_help()
         sys.exit(2)
     options, positional_args = option_parser.parse_args()
+
+    if not options.config_file_path:
+        if options.start_test_env or options.start_test_env_with_ssl:
+            options.config_file_path = 'manual_config.py'
+        else:
+            options.config_file_path = 'test_config.py'
 
     print 'Reading config from:', options.config_file_path
     print 'XtreemFS base dir  :', options.xtreemfs_dir


### PR DESCRIPTION
Currently 1 DIR, 1 MRC and 3 OSDs are started. This could be changed as well as the number of automatic created and mounted volumes.