### PR TITLE
Prevent multiple closing of XtreemFSFileOutputStream

### DIFF
--- a/contrib/hadoop/src/org/xtreemfs/common/clients/hadoop/XtreemFSFileOutputStream.java
+++ b/contrib/hadoop/src/org/xtreemfs/common/clients/hadoop/XtreemFSFileOutputStream.java
@@ -8,8 +8,6 @@ package org.xtreemfs.common.clients.hadoop;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.ByteBuffer;
 
 import org.xtreemfs.common.libxtreemfs.FileHandle;

--- a/contrib/hadoop/src/org/xtreemfs/common/clients/hadoop/XtreemFSFileOutputStream.java
+++ b/contrib/hadoop/src/org/xtreemfs/common/clients/hadoop/XtreemFSFileOutputStream.java
@@ -91,18 +91,13 @@ public class XtreemFSFileOutputStream extends OutputStream {
 
     @Override
     public synchronized void close() throws IOException {
-        if (Logging.isDebug()) {
-            Logging.logMessage(Logging.LEVEL_DEBUG, this, "Closing file %s", fileName);
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
-            new Throwable().printStackTrace(pw);
-            Logging.logMessage(Logging.LEVEL_DEBUG, this, "StackTrace: %s", sw.toString());
+        if (closed) {
+            Logging.logMessage(Logging.LEVEL_WARN, this, "Attempting to close already closed file %s", fileName);
+            return;
         }
         
-        if(closed) {
-            return;
-        } else {
-            closed = true;
+        if (Logging.isDebug()) {
+            Logging.logMessage(Logging.LEVEL_DEBUG, this, "Closing file %s", fileName);
         }
 
         if (useBuffer && buffer.position() > 0) {
@@ -113,6 +108,7 @@ public class XtreemFSFileOutputStream extends OutputStream {
         }
         super.close();
         fileHandle.close();
+        closed = true;
     }
 
     private synchronized void writeToBuffer(byte b[], int off, int len) throws IOException {

--- a/contrib/hadoop/src/org/xtreemfs/common/clients/hadoop/XtreemFSFileOutputStream.java
+++ b/contrib/hadoop/src/org/xtreemfs/common/clients/hadoop/XtreemFSFileOutputStream.java
@@ -8,6 +8,8 @@ package org.xtreemfs.common.clients.hadoop;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.ByteBuffer;
 
 import org.xtreemfs.common.libxtreemfs.FileHandle;
@@ -30,6 +32,8 @@ public class XtreemFSFileOutputStream extends OutputStream {
     private boolean         useBuffer;
 
     private ByteBuffer      buffer;
+    
+    private boolean         closed;
 
     public XtreemFSFileOutputStream(UserCredentials userCredentials, FileHandle fileHandle, String fileName,
             boolean useBuffer, int bufferSize) throws IOException {
@@ -42,6 +46,8 @@ public class XtreemFSFileOutputStream extends OutputStream {
         this.fileHandle = fileHandle;
         this.fileName = fileName;
         this.useBuffer = useBuffer;
+        this.closed = false;
+        
         if (useBuffer) {
             this.buffer = ByteBuffer.allocateDirect(bufferSize);
         }
@@ -87,6 +93,16 @@ public class XtreemFSFileOutputStream extends OutputStream {
     public synchronized void close() throws IOException {
         if (Logging.isDebug()) {
             Logging.logMessage(Logging.LEVEL_DEBUG, this, "Closing file %s", fileName);
+            StringWriter sw = new StringWriter();
+            PrintWriter pw = new PrintWriter(sw);
+            new Throwable().printStackTrace(pw);
+            Logging.logMessage(Logging.LEVEL_DEBUG, this, "StackTrace: %s", sw.toString());
+        }
+        
+        if(closed) {
+            return;
+        } else {
+            closed = true;
         }
 
         if (useBuffer && buffer.position() > 0) {

--- a/contrib/hadoop/src/org/xtreemfs/common/clients/hadoop/XtreemFSFileOutputStream.java
+++ b/contrib/hadoop/src/org/xtreemfs/common/clients/hadoop/XtreemFSFileOutputStream.java
@@ -90,7 +90,8 @@ public class XtreemFSFileOutputStream extends OutputStream {
     @Override
     public synchronized void close() throws IOException {
         if (closed) {
-            Logging.logMessage(Logging.LEVEL_WARN, this, "Attempting to close already closed file %s", fileName);
+            Logging.logMessage(Logging.LEVEL_WARN, this,
+                    "Ignoring attempt to close already closed file %s", fileName);
             return;
         }
         


### PR DESCRIPTION
Some frameworks (such as Apache Flink) close the output stream multiple times. To avoid segmentation faults, this PR adds a check to make sure an already closed output stream cannot be closed again.