### PR TITLE
OSD\replication: Bugfix: FileMetadata (filesize) hasn't been updated …

### DIFF
--- a/java/servers/src/org/xtreemfs/osd/storage/StorageThread.java
+++ b/java/servers/src/org/xtreemfs/osd/storage/StorageThread.java
@@ -87,11 +87,11 @@ public class StorageThread extends Stage {
     
     public static final int      STAGEOP_DELETE_OBJECTS        = 14;
     
-    private MetadataCache        cache;
+    private final MetadataCache        cache;
     
-    private StorageLayout        layout;
+    private final StorageLayout        layout;
     
-    private OSDRequestDispatcher master;
+    private final OSDRequestDispatcher master;
     
     private final boolean        checksumsEnabled;
     
@@ -529,7 +529,7 @@ public class StorageThread extends Stage {
             // if the write refers to the last known object or to an object
             // beyond, i.e. the file size and globalMax are potentially
             // affected:
-            if (objNo >= fi.getLastObjectNumber() && !gMaxOff) {
+            if (objNo >= fi.getLastObjectNumber()) {
                 
                 long newObjSize = dataLength + offset;
                 
@@ -568,7 +568,7 @@ public class StorageThread extends Stage {
                 // if the written object has a larger ID than the largest
                 // locally-known object of the file, send 'globalMax' messages
                 // to all other OSDs and update local globalMax
-                if (objNo > fi.getLastObjectNumber()) {
+                if (objNo > fi.getLastObjectNumber() && !gMaxOff) {
                     if (objNo > fi.getGlobalLastObjectNumber()) {
                         // send UDP packets...
                         final List<ServiceUUID> osds = xloc.getLocalReplica().getOSDs();


### PR DESCRIPTION
…after successful fetch object on replication, resulting in a wrong return value on get file size requests.