### PR TITLE
Fix external Hadoop dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 
-jdk: openjdk6
+jdk: openjdk7
 
 env:
   matrix:

--- a/contrib/hadoop/build.xml
+++ b/contrib/hadoop/build.xml
@@ -120,7 +120,12 @@
         <property name="libs.hadoop_common_dependencies.classpath" refid="hadoop_common_dependency_jars"/>
     </target>
 
-    <target name="-pre-init" depends="-set-junit-classpath,-set-hadoop-compile-classpaths,-set-hadoop-run-classpaths">
+    <target name="-pre-init" depends="-set-junit-classpath">
+        <!-- Empty target -->
+        <!-- Simply triggers invocation of the depending targets -->
+    </target>
+
+    <target name="-pre-compile-test" depends="-set-hadoop-compile-classpaths,-set-hadoop-run-classpaths">
         <!-- Empty target -->
         <!-- Simply triggers invocation of the depending targets -->
     </target>

--- a/contrib/hadoop/build.xml
+++ b/contrib/hadoop/build.xml
@@ -97,7 +97,7 @@
     </target>
 
     <!-- Sets Hadoop Classpaths for Test Compilation if not in NetBeans -->
-    <target name="-check-environment,-set-hadoop-compile-classpaths" if="hadoop.external">
+    <target name="-set-hadoop-compile-classpaths" depends="-check-environment" if="hadoop.external">
         <property environment="env"/>
 
         <path id="hadoop_common_tests_jar">
@@ -107,7 +107,7 @@
     </target>
 
     <!-- Sets Hadoop Classpaths for Test Execution if not in NetBeans -->
-    <target name="-check-environment,-set-hadoop-run-classpaths" if="hadoop.external">
+    <target name="-set-hadoop-run-classpaths" depends="-check-environment" if="hadoop.external">
         <property environment="env"/>
 
         <path id="hadoop_common_dependency_jars">

--- a/contrib/hadoop/build.xml
+++ b/contrib/hadoop/build.xml
@@ -97,10 +97,8 @@
     </target>
 
     <!-- Sets Hadoop Classpaths for Test Compilation if not in NetBeans -->
-    <target name="-set-hadoop-compile-classpaths" unless="netbeans.home">
+    <target name="-check-environment,-set-hadoop-compile-classpaths" if="hadoop.external">
         <property environment="env"/>
-
-        <echo level="info" message="Not in NetBeans; test compilation will fail if HADOOP_PREFIX is not set; your HADOOP_PREFIX points to: '${env.HADOOP_PREFIX}'."/>
 
         <path id="hadoop_common_tests_jar">
             <fileset dir="${env.HADOOP_PREFIX}/share/hadoop/common" includes="hadoop-common-*-tests.jar"/>
@@ -109,15 +107,25 @@
     </target>
 
     <!-- Sets Hadoop Classpaths for Test Execution if not in NetBeans -->
-    <target name="-set-hadoop-run-classpaths" unless="netbeans.home">
+    <target name="-check-environment,-set-hadoop-run-classpaths" if="hadoop.external">
         <property environment="env"/>
-
-        <echo level="info" message="Not in NetBeans; test execution will fail if HADOOP_PREFIX is not set; your HADOOP_PREFIX points to: '${env.HADOOP_PREFIX}'."/>
 
         <path id="hadoop_common_dependency_jars">
             <fileset dir="${env.HADOOP_PREFIX}/share/hadoop/common/lib" includes="*.jar"/>
         </path>
         <property name="libs.hadoop_common_dependencies.classpath" refid="hadoop_common_dependency_jars"/>
+    </target>
+
+    <target name="-check-environment">
+        <property environment="env"/>
+        <condition property="hadoop.external">
+            <and>
+                <isset property="env.HADOOP_PREFIX"/>
+                <not>
+                    <isset property="netbeans.home"/>
+                </not>
+            </and>
+        </condition>
     </target>
 
     <target name="-pre-init" depends="-set-junit-classpath,-set-hadoop-compile-classpaths,-set-hadoop-run-classpaths">

--- a/contrib/hadoop/build.xml
+++ b/contrib/hadoop/build.xml
@@ -100,7 +100,7 @@
     <target name="-set-hadoop-compile-classpaths" unless="netbeans.home">
         <property environment="env"/>
 
-        <fail unless="env.HADOOP_PREFIX" message="Not in NetBeans and no HADOOP_PREFIX set."/>
+        <echo level="info" message="Not in NetBeans; test compilation will fail if HADOOP_PREFIX is not set; your HADOOP_PREFIX points to: '${env.HADOOP_PREFIX}'."/>
 
         <path id="hadoop_common_tests_jar">
             <fileset dir="${env.HADOOP_PREFIX}/share/hadoop/common" includes="hadoop-common-*-tests.jar"/>
@@ -112,7 +112,7 @@
     <target name="-set-hadoop-run-classpaths" unless="netbeans.home">
         <property environment="env"/>
 
-        <fail unless="env.HADOOP_PREFIX" message="Not in NetBeans and no HADOOP_PREFIX set."/>
+        <echo level="info" message="Not in NetBeans; test execution will fail if HADOOP_PREFIX is not set; your HADOOP_PREFIX points to: '${env.HADOOP_PREFIX}'."/>
 
         <path id="hadoop_common_dependency_jars">
             <fileset dir="${env.HADOOP_PREFIX}/share/hadoop/common/lib" includes="*.jar"/>
@@ -120,12 +120,7 @@
         <property name="libs.hadoop_common_dependencies.classpath" refid="hadoop_common_dependency_jars"/>
     </target>
 
-    <target name="-pre-init" depends="-set-junit-classpath">
-        <!-- Empty target -->
-        <!-- Simply triggers invocation of the depending targets -->
-    </target>
-
-    <target name="-pre-compile-test" depends="-set-hadoop-compile-classpaths,-set-hadoop-run-classpaths">
+    <target name="-pre-init" depends="-set-junit-classpath,-set-hadoop-compile-classpaths,-set-hadoop-run-classpaths">
         <!-- Empty target -->
         <!-- Simply triggers invocation of the depending targets -->
     </target>

--- a/contrib/hadoop/build.xml
+++ b/contrib/hadoop/build.xml
@@ -120,14 +120,8 @@
         <property name="libs.hadoop_common_dependencies.classpath" refid="hadoop_common_dependency_jars"/>
     </target>
 
-    <target name="-pre-compile-test" depends="-set-junit-classpath,-set-hadoop-compile-classpaths">
+    <target name="-pre-init" depends="-set-junit-classpath,-set-hadoop-compile-classpaths,-set-hadoop-run-classpaths">
         <!-- Empty target -->
-    </target>
-
-    <target name="-pre-test-run" depends="-set-hadoop-run-classpaths">
-        <!-- Empty target -->
-    </target>
-    <target name="-pre-test-run-single" depends="-set-hadoop-run-classpaths">
-        <!-- Empty target -->
+        <!-- Simply triggers invocation of the depending targets -->
     </target>
 </project>

--- a/contrib/hadoop/build.xml
+++ b/contrib/hadoop/build.xml
@@ -116,6 +116,8 @@
         <property name="libs.hadoop_common_dependencies.classpath" refid="hadoop_common_dependency_jars"/>
     </target>
 
+    <!-- Sets project property 'hadoop.external' to true if not executed within NetBeans -->
+    <!-- and the environment variable 'HADOOP_PREFIX' is set -->
     <target name="-check-environment">
         <property environment="env"/>
         <condition property="hadoop.external">

--- a/contrib/hadoop/nbproject/build-impl.xml
+++ b/contrib/hadoop/nbproject/build-impl.xml
@@ -1248,7 +1248,8 @@ is divided into following sections:
         <mkdir dir="${build.test.classes.dir}"/>
     </target>
     <target name="-pre-compile-test">
-        <!-- This target is overridden in ../build.xml -->
+        <!-- Empty placeholder for easier customization. -->
+        <!-- You can override this target in the ../build.xml file. -->
     </target>
     <target if="do.depend.true" name="-compile-test-depend">
         <j2seproject3:depend classpath="${javac.test.classpath}" destdir="${build.test.classes.dir}" srcdir="${test.java.dir}"/>

--- a/contrib/hadoop/nbproject/build-impl.xml
+++ b/contrib/hadoop/nbproject/build-impl.xml
@@ -1248,8 +1248,7 @@ is divided into following sections:
         <mkdir dir="${build.test.classes.dir}"/>
     </target>
     <target name="-pre-compile-test">
-        <!-- Empty placeholder for easier customization. -->
-        <!-- You can override this target in the ../build.xml file. -->
+        <!-- This target is overridden in ../build.xml -->
     </target>
     <target if="do.depend.true" name="-compile-test-depend">
         <j2seproject3:depend classpath="${javac.test.classpath}" destdir="${build.test.classes.dir}" srcdir="${test.java.dir}"/>

--- a/contrib/hadoop/nbproject/build-impl.xml
+++ b/contrib/hadoop/nbproject/build-impl.xml
@@ -34,8 +34,7 @@ is divided into following sections:
                 ======================
             -->
     <target name="-pre-init">
-        <!-- Empty placeholder for easier customization. -->
-        <!-- You can override this target in the ../build.xml file. -->
+        <!-- This target is overridden in ../build.xml -->
     </target>
     <target depends="-pre-init" name="-init-private">
         <property file="nbproject/private/config.properties"/>
@@ -1249,7 +1248,8 @@ is divided into following sections:
         <mkdir dir="${build.test.classes.dir}"/>
     </target>
     <target name="-pre-compile-test">
-        <!-- This target is overridden in ../build.xml -->
+        <!-- Empty placeholder for easier customization. -->
+        <!-- You can override this target in the ../build.xml file. -->
     </target>
     <target if="do.depend.true" name="-compile-test-depend">
         <j2seproject3:depend classpath="${javac.test.classpath}" destdir="${build.test.classes.dir}" srcdir="${test.java.dir}"/>
@@ -1287,54 +1287,48 @@ is divided into following sections:
                 TEST EXECUTION SECTION
                 =======================
             -->
-    <target depends="init" if="have.tests" name="-pre-pre-test-run">
+    <target depends="init" if="have.tests" name="-pre-test-run">
         <mkdir dir="${build.test.results.dir}"/>
     </target>
-    <target name="-pre-test-run">
-        <!-- This target is overridden in ../build.xml -->
-    </target>
-    <target depends="init,compile-test,-pre-pre-test-run,-pre-test-run" if="have.tests" name="-do-test-run">
+    <target depends="init,compile-test,-pre-test-run" if="have.tests" name="-do-test-run">
         <j2seproject3:test includes="${includes}" testincludes="**/*Test.java"/>
     </target>
-    <target depends="init,compile-test,-pre-pre-test-run,-pre-test-run,-do-test-run" if="have.tests" name="-post-test-run">
+    <target depends="init,compile-test,-pre-test-run,-do-test-run" if="have.tests" name="-post-test-run">
         <fail if="tests.failed" unless="ignore.failing.tests">Some tests failed; see details above.</fail>
     </target>
     <target depends="init" if="have.tests" name="test-report"/>
     <target depends="init" if="netbeans.home+have.tests" name="-test-browse"/>
-    <target depends="init,compile-test,-pre-pre-test-run,-pre-test-run,-do-test-run,test-report,-post-test-run,-test-browse" description="Run unit tests." name="test"/>
-    <target depends="init" if="have.tests" name="-pre-pre-test-run-single">
+    <target depends="init,compile-test,-pre-test-run,-do-test-run,test-report,-post-test-run,-test-browse" description="Run unit tests." name="test"/>
+    <target depends="init" if="have.tests" name="-pre-test-run-single">
         <mkdir dir="${build.test.results.dir}"/>
     </target>
-    <target name="-pre-test-run-single">
-        <!-- This target is overridden in ../build.xml -->
-    </target>
-    <target depends="init,compile-test-single,-pre-pre-test-run-single,-pre-test-run-single" if="have.tests" name="-do-test-run-single">
+    <target depends="init,compile-test-single,-pre-test-run-single" if="have.tests" name="-do-test-run-single">
         <fail unless="test.includes">Must select some files in the IDE or set test.includes</fail>
         <j2seproject3:test excludes="" includes="${test.includes}" testincludes="${test.includes}"/>
     </target>
-    <target depends="init,compile-test-single,-pre-pre-test-run-single,-pre-test-run-single,-do-test-run-single" if="have.tests" name="-post-test-run-single">
+    <target depends="init,compile-test-single,-pre-test-run-single,-do-test-run-single" if="have.tests" name="-post-test-run-single">
         <fail if="tests.failed" unless="ignore.failing.tests">Some tests failed; see details above.</fail>
     </target>
-    <target depends="init,compile-test-single,-pre-pre-test-run-single,-pre-test-run-single,-do-test-run-single,-post-test-run-single" description="Run single unit test." name="test-single"/>
-    <target depends="init,compile-test-single,-pre-pre-test-run-single,-pre-test-run-single" if="have.tests" name="-do-test-run-single-method">
+    <target depends="init,compile-test-single,-pre-test-run-single,-do-test-run-single,-post-test-run-single" description="Run single unit test." name="test-single"/>
+    <target depends="init,compile-test-single,-pre-test-run-single" if="have.tests" name="-do-test-run-single-method">
         <fail unless="test.class">Must select some files in the IDE or set test.class</fail>
         <fail unless="test.method">Must select some method in the IDE or set test.method</fail>
         <j2seproject3:test excludes="" includes="${javac.includes}" testincludes="${test.class}" testmethods="${test.method}"/>
     </target>
-    <target depends="init,compile-test-single,-pre-pre-test-run-single,-pre-test-run-single,-do-test-run-single-method" if="have.tests" name="-post-test-run-single-method">
+    <target depends="init,compile-test-single,-pre-test-run-single,-do-test-run-single-method" if="have.tests" name="-post-test-run-single-method">
         <fail if="tests.failed" unless="ignore.failing.tests">Some tests failed; see details above.</fail>
     </target>
-    <target depends="init,compile-test-single,-pre-pre-test-run-single,-pre-test-run-single,-do-test-run-single-method,-post-test-run-single-method" description="Run single unit test." name="test-single-method"/>
+    <target depends="init,compile-test-single,-pre-test-run-single,-do-test-run-single-method,-post-test-run-single-method" description="Run single unit test." name="test-single-method"/>
     <!--
                 =======================
                 TEST DEBUGGING SECTION
                 =======================
             -->
-    <target depends="init,compile-test-single,-pre-pre-test-run-single,-pre-test-run-single" if="have.tests" name="-debug-start-debuggee-test">
+    <target depends="init,compile-test-single,-pre-test-run-single" if="have.tests" name="-debug-start-debuggee-test">
         <fail unless="test.class">Must select one file in the IDE or set test.class</fail>
         <j2seproject3:test-debug excludes="" includes="${javac.includes}" testClass="${test.class}" testincludes="${javac.includes}"/>
     </target>
-    <target depends="init,compile-test-single,-pre-pre-test-run-single,-pre-test-run-single" if="have.tests" name="-debug-start-debuggee-test-method">
+    <target depends="init,compile-test-single,-pre-test-run-single" if="have.tests" name="-debug-start-debuggee-test-method">
         <fail unless="test.class">Must select one file in the IDE or set test.class</fail>
         <fail unless="test.method">Must select some method in the IDE or set test.method</fail>
         <j2seproject3:test-debug excludes="" includes="${javac.includes}" testClass="${test.class}" testMethod="${test.method}" testincludes="${test.class}" testmethods="${test.method}"/>

--- a/tests/test_scripts/hadoop_junit_tests.sh
+++ b/tests/test_scripts/hadoop_junit_tests.sh
@@ -27,7 +27,7 @@ for VERSION in $HADOOP_VERSIONS; do
   echo "Set HADOOP_HOME=HADOOP_PREFIX=$HADOOP_PREFIX"
 
   echo "Running JUnit Tests for Hadoop Adapter and Hadoop $VERSION..."
-  ant test -v -d -f $XTREEMFS/contrib/hadoop/build.xml 2>&1 > $TEST_DIR/log/hadoop-$VERSION-junit.log
+  ant test -v -d -f $XTREEMFS/contrib/hadoop/build.xml -Djava.library.path=$XTREEMFS/cpp/build 2>&1 > $TEST_DIR/log/hadoop-$VERSION-junit.log
 
   grep "BUILD SUCCESSFUL" $TEST_DIR/log/hadoop-$VERSION-junit.log >/dev/null
   cat $TEST_DIR/log/hadoop-$VERSION-junit.log

--- a/tests/test_scripts/hadoop_junit_tests.sh
+++ b/tests/test_scripts/hadoop_junit_tests.sh
@@ -30,6 +30,7 @@ for VERSION in $HADOOP_VERSIONS; do
   ant test -f $XTREEMFS/contrib/hadoop/build.xml 2>&1 > $TEST_DIR/log/hadoop-$VERSION-junit.log
 
   grep "BUILD SUCCESSFUL" $TEST_DIR/log/hadoop-$VERSION-junit.log >/dev/null
+  cat $TEST_DIR/log/hadoop-$VERSION-junit.log
   if [ $? -eq 0 ]; then
     echo "JUnit Tests for Hadoop Adapter and Hadoop $VERSION successful."
   else

--- a/tests/test_scripts/hadoop_junit_tests.sh
+++ b/tests/test_scripts/hadoop_junit_tests.sh
@@ -27,10 +27,9 @@ for VERSION in $HADOOP_VERSIONS; do
   echo "Set HADOOP_HOME=HADOOP_PREFIX=$HADOOP_PREFIX"
 
   echo "Running JUnit Tests for Hadoop Adapter and Hadoop $VERSION..."
-  ant test -v -d -f $XTREEMFS/contrib/hadoop/build.xml -Djava.library.path=$XTREEMFS/cpp/build 2>&1 > $TEST_DIR/log/hadoop-$VERSION-junit.log
+  ant test -f $XTREEMFS/contrib/hadoop/build.xml -Djava.library.path=$XTREEMFS/cpp/build 2>&1 > $TEST_DIR/log/hadoop-$VERSION-junit.log
 
   grep "BUILD SUCCESSFUL" $TEST_DIR/log/hadoop-$VERSION-junit.log >/dev/null
-  cat $TEST_DIR/log/hadoop-$VERSION-junit.log
   if [ $? -eq 0 ]; then
     echo "JUnit Tests for Hadoop Adapter and Hadoop $VERSION successful."
   else

--- a/tests/test_scripts/hadoop_junit_tests.sh
+++ b/tests/test_scripts/hadoop_junit_tests.sh
@@ -27,7 +27,7 @@ for VERSION in $HADOOP_VERSIONS; do
   echo "Set HADOOP_HOME=HADOOP_PREFIX=$HADOOP_PREFIX"
 
   echo "Running JUnit Tests for Hadoop Adapter and Hadoop $VERSION..."
-  ant test -f $XTREEMFS/contrib/hadoop/build.xml 2>&1 > $TEST_DIR/log/hadoop-$VERSION-junit.log
+  ant test -v -d -f $XTREEMFS/contrib/hadoop/build.xml 2>&1 > $TEST_DIR/log/hadoop-$VERSION-junit.log
 
   grep "BUILD SUCCESSFUL" $TEST_DIR/log/hadoop-$VERSION-junit.log >/dev/null
   cat $TEST_DIR/log/hadoop-$VERSION-junit.log


### PR DESCRIPTION
This PR fixes the XtreemFS Hadoop adapter test compilation and execution dependencies when not run from NetBeans. If in NetBeans, these properties need to be specified within the project. If not in NetBeans, the environment variable HADOOP_PREFIX needs to be defined for the tests to be compiled and executed.

Furthermore Travis CI has been switched to use OpenJDK 7.