### PR TITLE
Hadoop interoperability

### DIFF
--- a/contrib/hadoop/nbproject/build-impl.xml
+++ b/contrib/hadoop/nbproject/build-impl.xml
@@ -1291,7 +1291,7 @@ is divided into following sections:
         <mkdir dir="${build.test.results.dir}"/>
     </target>
     <target depends="init,compile-test,-pre-test-run" if="have.tests" name="-do-test-run">
-        <j2seproject3:test includes="${includes}" testincludes="**/*Test.java"/>
+        <j2seproject3:test includes="${includes}" testincludes="org/xtreemfs/**/*Test.java"/>
     </target>
     <target depends="init,compile-test,-pre-test-run,-do-test-run" if="have.tests" name="-post-test-run">
         <fail if="tests.failed" unless="ignore.failing.tests">Some tests failed; see details above.</fail>

--- a/contrib/hadoop/src/main/java/org/xtreemfs/common/clients/hadoop/XtreemFSFileSystem.java
+++ b/contrib/hadoop/src/main/java/org/xtreemfs/common/clients/hadoop/XtreemFSFileSystem.java
@@ -70,7 +70,7 @@ public class XtreemFSFileSystem extends FileSystem {
     private Volume              defaultVolume;
     private static final int    STANDARD_DIR_PORT = 32638;
     private static final int[]  MIN_HADOOP_VERSION = { 0, 0, 0 };
-    private static final int[] MAX_HADOOP_VERSION =
+    private static final int[]  MAX_HADOOP_VERSION =
             { 2, Integer.MAX_VALUE, Integer.MAX_VALUE };
     private static String STANDARD_HADOOP_VERSION = "2.2.0";
 

--- a/contrib/hadoop/src/main/java/org/xtreemfs/common/clients/hadoop/XtreemFSFileSystem.java
+++ b/contrib/hadoop/src/main/java/org/xtreemfs/common/clients/hadoop/XtreemFSFileSystem.java
@@ -72,7 +72,7 @@ public class XtreemFSFileSystem extends FileSystem {
     private static final int[]  MIN_HADOOP_VERSION = { 0, 0, 0 };
     private static final int[]  MAX_HADOOP_VERSION =
             { 2, Integer.MAX_VALUE, Integer.MAX_VALUE };
-    private static String STANDARD_HADOOP_VERSION = "2.2.0";
+    private static final String STANDARD_HADOOP_VERSION = "2.2.0";
 
     @Override
     public void initialize(URI uri, Configuration conf) throws IOException {

--- a/contrib/hadoop/src/test/java/org/apache/hadoop/fs/Hadoop1FileSystemContractBaseTest.java
+++ b/contrib/hadoop/src/test/java/org/apache/hadoop/fs/Hadoop1FileSystemContractBaseTest.java
@@ -1,0 +1,473 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.fs;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import junit.framework.TestCase;
+
+/**
+ * <p>
+ * A collection of tests for the contract of the {@link FileSystem}. This test
+ * should be used for general-purpose implementations of {@link FileSystem},
+ * that is, implementations that provide implementations of all of the
+ * functionality of {@link FileSystem}.
+ * </p>
+ * <p>
+ * To test a given {@link FileSystem} implementation create a subclass of this
+ * test and override {@link #setUp()} to initialize the <code>fs</code>
+ * {@link FileSystem} instance variable.
+ * </p>
+ */
+public abstract class Hadoop1FileSystemContractBaseTest extends TestCase {
+
+    protected FileSystem fs;
+    protected byte[] data = new byte[getBlockSize() * 2]; // two blocks of data
+
+    {
+        for (int i = 0; i < data.length; i++) {
+            data[i] = (byte) (i % 10);
+        }
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        fs.delete(path("/test"), true);
+    }
+
+    protected int getBlockSize() {
+        return 1024;
+    }
+
+    protected String getDefaultWorkingDirectory() {
+        return "/user/" + System.getProperty("user.name");
+    }
+
+    protected boolean renameSupported() {
+        return true;
+    }
+
+    public void testWorkingDirectory() throws Exception {
+
+        Path workDir = path(getDefaultWorkingDirectory());
+        assertEquals(workDir, fs.getWorkingDirectory());
+
+        fs.setWorkingDirectory(path("."));
+        assertEquals(workDir, fs.getWorkingDirectory());
+
+        fs.setWorkingDirectory(path(".."));
+        assertEquals(workDir.getParent(), fs.getWorkingDirectory());
+
+        Path relativeDir = path("hadoop");
+        fs.setWorkingDirectory(relativeDir);
+        assertEquals(relativeDir, fs.getWorkingDirectory());
+
+        Path absoluteDir = path("/test/hadoop");
+        fs.setWorkingDirectory(absoluteDir);
+        assertEquals(absoluteDir, fs.getWorkingDirectory());
+
+    }
+
+    public void testMkdirs() throws Exception {
+        Path testDir = path("/test/hadoop");
+        assertFalse(fs.exists(testDir));
+        assertFalse(fs.isFile(testDir));
+
+        assertTrue(fs.mkdirs(testDir));
+
+        assertTrue(fs.exists(testDir));
+        assertFalse(fs.isFile(testDir));
+
+        assertTrue(fs.mkdirs(testDir));
+
+        assertTrue(fs.exists(testDir));
+        assertFalse(fs.isFile(testDir));
+
+        Path parentDir = testDir.getParent();
+        assertTrue(fs.exists(parentDir));
+        assertFalse(fs.isFile(parentDir));
+
+        Path grandparentDir = parentDir.getParent();
+        assertTrue(fs.exists(grandparentDir));
+        assertFalse(fs.isFile(grandparentDir));
+
+    }
+
+    public void testMkdirsFailsForSubdirectoryOfExistingFile() throws Exception {
+        Path testDir = path("/test/hadoop");
+        assertFalse(fs.exists(testDir));
+        assertTrue(fs.mkdirs(testDir));
+        assertTrue(fs.exists(testDir));
+
+        createFile(path("/test/hadoop/file"));
+
+        Path testSubDir = path("/test/hadoop/file/subdir");
+        try {
+            fs.mkdirs(testSubDir);
+            fail("Should throw IOException.");
+        } catch (IOException e) {
+            // expected
+        }
+        assertFalse(fs.exists(testSubDir));
+
+        Path testDeepSubDir = path("/test/hadoop/file/deep/sub/dir");
+        try {
+            fs.mkdirs(testDeepSubDir);
+            fail("Should throw IOException.");
+        } catch (IOException e) {
+            // expected
+        }
+        assertFalse(fs.exists(testDeepSubDir));
+
+    }
+
+    public void testGetFileStatusThrowsExceptionForNonExistentFile()
+            throws Exception {
+        try {
+            fs.getFileStatus(path("/test/hadoop/file"));
+            fail("Should throw FileNotFoundException");
+        } catch (FileNotFoundException e) {
+            // expected
+        }
+    }
+
+    public void testListStatusReturnsNullForNonExistentFile() throws Exception {
+        assertNull(fs.listStatus(path("/test/hadoop/file")));
+    }
+
+    public void testListStatus() throws Exception {
+        Path[] testDirs = {path("/test/hadoop/a"),
+            path("/test/hadoop/b"),
+            path("/test/hadoop/c/1"),};
+        assertFalse(fs.exists(testDirs[0]));
+
+        for (Path path : testDirs) {
+            assertTrue(fs.mkdirs(path));
+        }
+
+        FileStatus[] paths = fs.listStatus(path("/test"));
+        assertEquals(1, paths.length);
+        assertEquals(path("/test/hadoop"), paths[0].getPath());
+
+        paths = fs.listStatus(path("/test/hadoop"));
+        assertEquals(3, paths.length);
+        assertEquals(path("/test/hadoop/a"), paths[0].getPath());
+        assertEquals(path("/test/hadoop/b"), paths[1].getPath());
+        assertEquals(path("/test/hadoop/c"), paths[2].getPath());
+
+        paths = fs.listStatus(path("/test/hadoop/a"));
+        assertEquals(0, paths.length);
+    }
+
+    public void testWriteReadAndDeleteEmptyFile() throws Exception {
+        writeReadAndDelete(0);
+    }
+
+    public void testWriteReadAndDeleteHalfABlock() throws Exception {
+        writeReadAndDelete(getBlockSize() / 2);
+    }
+
+    public void testWriteReadAndDeleteOneBlock() throws Exception {
+        writeReadAndDelete(getBlockSize());
+    }
+
+    public void testWriteReadAndDeleteOneAndAHalfBlocks() throws Exception {
+        writeReadAndDelete(getBlockSize() + (getBlockSize() / 2));
+    }
+
+    public void testWriteReadAndDeleteTwoBlocks() throws Exception {
+        writeReadAndDelete(getBlockSize() * 2);
+    }
+
+    protected void writeReadAndDelete(int len) throws IOException {
+        Path path = path("/test/hadoop/file");
+
+        fs.mkdirs(path.getParent());
+
+        FSDataOutputStream out = fs.create(path, false,
+                fs.getConf().getInt("io.file.buffer.size", 4096),
+                (short) 1, getBlockSize());
+        out.write(data, 0, len);
+        out.close();
+
+        assertTrue("Exists", fs.exists(path));
+        assertEquals("Length", len, fs.getFileStatus(path).getLen());
+
+        FSDataInputStream in = fs.open(path);
+        byte[] buf = new byte[len];
+        in.readFully(0, buf);
+        in.close();
+
+        assertEquals(len, buf.length);
+        for (int i = 0; i < buf.length; i++) {
+            assertEquals("Position " + i, data[i], buf[i]);
+        }
+
+        assertTrue("Deleted", fs.delete(path, false));
+
+        assertFalse("No longer exists", fs.exists(path));
+
+    }
+
+    public void testOverwrite() throws IOException {
+        Path path = path("/test/hadoop/file");
+
+        fs.mkdirs(path.getParent());
+
+        createFile(path);
+
+        assertTrue("Exists", fs.exists(path));
+        assertEquals("Length", data.length, fs.getFileStatus(path).getLen());
+
+        try {
+            fs.create(path, false).close();
+            fail("Should throw IOException.");
+        } catch (IOException e) {
+            // Expected
+        }
+
+        FSDataOutputStream out = fs.create(path, true);
+        out.write(data, 0, data.length);
+        out.close();
+
+        assertTrue("Exists", fs.exists(path));
+        assertEquals("Length", data.length, fs.getFileStatus(path).getLen());
+
+    }
+
+    public void testWriteInNonExistentDirectory() throws IOException {
+        Path path = path("/test/hadoop/file");
+        assertFalse("Parent doesn't exist", fs.exists(path.getParent()));
+        createFile(path);
+
+        assertTrue("Exists", fs.exists(path));
+        assertEquals("Length", data.length, fs.getFileStatus(path).getLen());
+        assertTrue("Parent exists", fs.exists(path.getParent()));
+    }
+
+    public void testDeleteNonExistentFile() throws IOException {
+        Path path = path("/test/hadoop/file");
+        assertFalse("Doesn't exist", fs.exists(path));
+        assertFalse("No deletion", fs.delete(path, true));
+    }
+
+    public void testDeleteRecursively() throws IOException {
+        Path dir = path("/test/hadoop");
+        Path file = path("/test/hadoop/file");
+        Path subdir = path("/test/hadoop/subdir");
+
+        createFile(file);
+        assertTrue("Created subdir", fs.mkdirs(subdir));
+
+        assertTrue("File exists", fs.exists(file));
+        assertTrue("Dir exists", fs.exists(dir));
+        assertTrue("Subdir exists", fs.exists(subdir));
+
+        try {
+            fs.delete(dir, false);
+            fail("Should throw IOException.");
+        } catch (IOException e) {
+            // expected
+        }
+        assertTrue("File still exists", fs.exists(file));
+        assertTrue("Dir still exists", fs.exists(dir));
+        assertTrue("Subdir still exists", fs.exists(subdir));
+
+        assertTrue("Deleted", fs.delete(dir, true));
+        assertFalse("File doesn't exist", fs.exists(file));
+        assertFalse("Dir doesn't exist", fs.exists(dir));
+        assertFalse("Subdir doesn't exist", fs.exists(subdir));
+    }
+
+    public void testDeleteEmptyDirectory() throws IOException {
+        Path dir = path("/test/hadoop");
+        assertTrue(fs.mkdirs(dir));
+        assertTrue("Dir exists", fs.exists(dir));
+        assertTrue("Deleted", fs.delete(dir, false));
+        assertFalse("Dir doesn't exist", fs.exists(dir));
+    }
+
+    public void testRenameNonExistentPath() throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/path");
+        Path dst = path("/test/new/newpath");
+        rename(src, dst, false, false, false);
+    }
+
+    public void testRenameFileMoveToNonExistentDirectory() throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/file");
+        createFile(src);
+        Path dst = path("/test/new/newfile");
+        rename(src, dst, false, true, false);
+    }
+
+    public void testRenameFileMoveToExistingDirectory() throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/file");
+        createFile(src);
+        Path dst = path("/test/new/newfile");
+        fs.mkdirs(dst.getParent());
+        rename(src, dst, true, false, true);
+    }
+
+    public void testRenameFileAsExistingFile() throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/file");
+        createFile(src);
+        Path dst = path("/test/new/newfile");
+        createFile(dst);
+        rename(src, dst, false, true, true);
+    }
+
+    public void testRenameFileAsExistingDirectory() throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/file");
+        createFile(src);
+        Path dst = path("/test/new/newdir");
+        fs.mkdirs(dst);
+        rename(src, dst, true, false, true);
+        assertTrue("Destination changed",
+                fs.exists(path("/test/new/newdir/file")));
+    }
+
+    public void testRenameDirectoryMoveToNonExistentDirectory()
+            throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/dir");
+        fs.mkdirs(src);
+        Path dst = path("/test/new/newdir");
+        rename(src, dst, false, true, false);
+    }
+
+    public void testRenameDirectoryMoveToExistingDirectory() throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/dir");
+        fs.mkdirs(src);
+        createFile(path("/test/hadoop/dir/file1"));
+        createFile(path("/test/hadoop/dir/subdir/file2"));
+
+        Path dst = path("/test/new/newdir");
+        fs.mkdirs(dst.getParent());
+        rename(src, dst, true, false, true);
+
+        assertFalse("Nested file1 exists",
+                fs.exists(path("/test/hadoop/dir/file1")));
+        assertFalse("Nested file2 exists",
+                fs.exists(path("/test/hadoop/dir/subdir/file2")));
+        assertTrue("Renamed nested file1 exists",
+                fs.exists(path("/test/new/newdir/file1")));
+        assertTrue("Renamed nested exists",
+                fs.exists(path("/test/new/newdir/subdir/file2")));
+    }
+
+    public void testRenameDirectoryAsExistingFile() throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/dir");
+        fs.mkdirs(src);
+        Path dst = path("/test/new/newfile");
+        createFile(dst);
+        rename(src, dst, false, true, true);
+    }
+
+    public void testRenameDirectoryAsExistingDirectory() throws Exception {
+        if (!renameSupported()) {
+            return;
+        }
+
+        Path src = path("/test/hadoop/dir");
+        fs.mkdirs(src);
+        createFile(path("/test/hadoop/dir/file1"));
+        createFile(path("/test/hadoop/dir/subdir/file2"));
+
+        Path dst = path("/test/new/newdir");
+        fs.mkdirs(dst);
+        rename(src, dst, true, false, true);
+        assertTrue("Destination changed",
+                fs.exists(path("/test/new/newdir/dir")));
+        assertFalse("Nested file1 exists",
+                fs.exists(path("/test/hadoop/dir/file1")));
+        assertFalse("Nested file2 exists",
+                fs.exists(path("/test/hadoop/dir/subdir/file2")));
+        assertTrue("Renamed nested file1 exists",
+                fs.exists(path("/test/new/newdir/dir/file1")));
+        assertTrue("Renamed nested exists",
+                fs.exists(path("/test/new/newdir/dir/subdir/file2")));
+    }
+
+    public void testInputStreamClosedTwice() throws IOException {
+        //HADOOP-4760 according to Closeable#close() closing already-closed 
+        //streams should have no effect. 
+        Path src = path("/test/hadoop/file");
+        createFile(src);
+        FSDataInputStream in = fs.open(src);
+        in.close();
+        in.close();
+    }
+
+    public void testOutputStreamClosedTwice() throws IOException {
+        //HADOOP-4760 according to Closeable#close() closing already-closed 
+        //streams should have no effect. 
+        Path src = path("/test/hadoop/file");
+        FSDataOutputStream out = fs.create(src);
+        out.writeChar('H'); //write some data
+        out.close();
+        out.close();
+    }
+
+    protected Path path(String pathString) {
+        return new Path(pathString).makeQualified(fs);
+    }
+
+    protected void createFile(Path path) throws IOException {
+        FSDataOutputStream out = fs.create(path);
+        out.write(data, 0, data.length);
+        out.close();
+    }
+
+    private void rename(Path src, Path dst, boolean renameSucceeded,
+            boolean srcExists, boolean dstExists) throws IOException {
+        assertEquals("Rename result", renameSucceeded, fs.rename(src, dst));
+        assertEquals("Source exists", srcExists, fs.exists(src));
+        assertEquals("Destination exists", dstExists, fs.exists(dst));
+    }
+}

--- a/contrib/hadoop/src/test/java/org/xtreemfs/common/clients/hadoop/XtreemFSFileSystemContractTest.java
+++ b/contrib/hadoop/src/test/java/org/xtreemfs/common/clients/hadoop/XtreemFSFileSystemContractTest.java
@@ -20,7 +20,7 @@ import org.xtreemfs.foundation.pbrpc.client.RPCAuthentication;
 import org.xtreemfs.foundation.pbrpc.generatedinterfaces.RPC.UserCredentials;
 
 /**
- * Executes file system contract tests with XtreemFS initialized from
+ * Executes Hadoop 2 file system contract tests with XtreemFS initialized from
  * <code>xtreemfs.defaultVolumeName</code>.
  */
 public class XtreemFSFileSystemContractTest extends FileSystemContractBaseTest {

--- a/contrib/hadoop/src/test/java/org/xtreemfs/common/clients/hadoop/XtreemFSHadoop1FileSystemContractTest.java
+++ b/contrib/hadoop/src/test/java/org/xtreemfs/common/clients/hadoop/XtreemFSHadoop1FileSystemContractTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2015 by Robert Schmidtke, Zuse Institute Berlin
+ *
+ * Licensed under the BSD License, see LICENSE file for details.
+ *
+ */
+package org.xtreemfs.common.clients.hadoop;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileSystemContractBaseTest;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.contract.ContractTestUtils;
+import org.xtreemfs.common.libxtreemfs.Client;
+import org.xtreemfs.common.libxtreemfs.ClientFactory;
+import org.xtreemfs.common.libxtreemfs.Options;
+import org.xtreemfs.foundation.pbrpc.client.RPCAuthentication;
+import org.xtreemfs.foundation.pbrpc.generatedinterfaces.RPC.UserCredentials;
+
+/**
+ * Executes file system contract tests with XtreemFS initialized from
+ * <code>xtreemfs.defaultVolumeName</code>.
+ */
+public class XtreemFSFileSystemContractTest extends FileSystemContractBaseTest {
+
+    protected final Client client;
+
+    protected final UserCredentials userCredentials;
+
+    protected final Path fileSystemPath;
+
+    protected final Path dirPath, mrcPath;
+
+    protected static final String DEFAULT_VOLUME_NAME = "hadoopJUnitTest",
+            UNUSED_VOLUME_NAME = DEFAULT_VOLUME_NAME + "_";
+
+    protected final Configuration conf;
+    
+    // whether to set xtreemfs.defaultVolumeName during setUp, defaults to true
+    protected boolean setXtreemFSDefaultVolumeName;
+    
+    // whether to instantiate the file system using FileSystem.get, defaults to true
+    protected boolean useFSFactory;
+
+    public XtreemFSFileSystemContractTest() {
+        this("xtreemfs://localhost:32638", "xtreemfs://localhost:32638",
+                "xtreemfs://localhost:32636");
+    }
+
+    protected XtreemFSFileSystemContractTest(String fileSystemUri,
+            String dirUri, String mrcUri) {
+        this.fileSystemPath = new Path(fileSystemUri);
+        this.dirPath = new Path(dirUri);
+        this.mrcPath = new Path(mrcUri);
+
+        Configuration.addDefaultResource(XtreemFSFileSystemContractTest.class
+                .getClassLoader().getResource("core-site.xml").getPath());
+        conf = new Configuration();
+
+        userCredentials = UserCredentials.newBuilder().setUsername("test")
+                .addGroups("test").build();
+
+        client = ClientFactory.createClient(ClientFactory.ClientType.NATIVE,
+                dirPath.toUri().getAuthority(), userCredentials, null, new Options());
+        
+        setXtreemFSDefaultVolumeName = true;
+        useFSFactory = true;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        System.out.println("Executing TestCase: '" + getName() + "'.");
+
+        client.start();
+        client.createVolume(mrcPath.toUri().getAuthority(), RPCAuthentication.authNone,
+                userCredentials, DEFAULT_VOLUME_NAME);
+        client.createVolume(mrcPath.toUri().getAuthority(), RPCAuthentication.authNone,
+                userCredentials, UNUSED_VOLUME_NAME);
+        
+        conf.set("xtreemfs.jni.libraryPath", System.getenv("XTREEMFS")
+                + "/cpp/build");
+        if (setXtreemFSDefaultVolumeName) {
+            conf.set("xtreemfs.defaultVolumeName", DEFAULT_VOLUME_NAME);
+        }
+
+        if (useFSFactory) {
+            fs = FileSystem.get(fileSystemPath.toUri(), conf);
+        } else {
+            fs = new XtreemFSFileSystem();
+            fs.initialize(fileSystemPath.toUri(), conf);
+        }
+
+        super.setUp();
+    }
+
+    /**
+     * Tests proper handling of correct URIs, in particular:<br />
+     * <code>
+     * xtreemfs://server:port/volume/path/to/file<br />
+     * xtreemfs://server/volume/path/to/file<br />
+     * xtreemfs:/path/to/file<br />
+     * //server:port/volume/path/to/file<br />
+     * //server/volume/path/to/file<br />
+     * /path/to/file<br />
+     * path/to/file<br />
+     * ./path/to/file<br />
+     * ../path/to/file
+     * </code>
+     *
+     * @throws Exception
+     */
+    public void testFileURIs() throws Exception {
+        String expected = "xtreemfs://" + dirPath.toUri().getAuthority() + "/"
+                + DEFAULT_VOLUME_NAME + "/path/to/file";
+
+        // xtreemfs://localhost:32638/hadoopJUnitTest/path/to/file
+        assertFileCreated(expected, expected);
+
+        // xtreemfs://localhost/hadoopJUnitTest/path/to/file
+        assertFileCreated(
+                "xtreemfs://" + dirPath.toUri().getHost() + "/" + DEFAULT_VOLUME_NAME + "/path/to/file",
+                expected);
+
+        // xtreemfs:/path/to/file
+        assertFileCreated("xtreemfs:/path/to/file", expected);
+
+        // //localhost:32638/hadoopJUnitTest/path/to/file
+        assertFileCreated(
+                "//" + dirPath.toUri().getAuthority() + "/" + DEFAULT_VOLUME_NAME + "/path/to/file",
+                expected);
+
+        // //localhost/hadoopJUnitTest/path/to/file
+        assertFileCreated(
+                "//" + dirPath.toUri().getHost() + "/" + DEFAULT_VOLUME_NAME + "/path/to/file",
+                expected);
+
+        // /path/to/file
+        assertFileCreated("/path/to/file", expected);
+
+        expected = "xtreemfs://" + dirPath.toUri().getAuthority() + "/"
+                + DEFAULT_VOLUME_NAME + "/user/" + System.getProperty("user.name")
+                + "/path/to/file";
+
+        // path/to/file
+        assertFileCreated("path/to/file", expected);
+
+        // ./path/to/file
+        assertFileCreated("./path/to/file", expected);
+
+        expected = "xtreemfs://" + dirPath.toUri().getAuthority() + "/"
+                + DEFAULT_VOLUME_NAME + "/user/path/to/file";
+
+        // ../path/to/file
+        assertFileCreated("../path/to/file", expected);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+
+        client.deleteVolume(mrcPath.toUri().getAuthority(), RPCAuthentication.authNone,
+                userCredentials, DEFAULT_VOLUME_NAME);
+        client.deleteVolume(mrcPath.toUri().getAuthority(), RPCAuthentication.authNone,
+                userCredentials, UNUSED_VOLUME_NAME);
+        client.shutdown();
+    }
+
+    protected void assertFileCreated(String path, String expected) throws IOException {
+        FSDataOutputStream file = fs.create(new Path(path));
+        ContractTestUtils.assertIsFile(fs, new Path(expected));
+        ContractTestUtils.assertDeleted(fs, new Path(expected), true);
+        file.close();
+    }
+
+}

--- a/contrib/hadoop/src/test/java/org/xtreemfs/common/clients/hadoop/XtreemFSHadoop1FileSystemContractTest.java
+++ b/contrib/hadoop/src/test/java/org/xtreemfs/common/clients/hadoop/XtreemFSHadoop1FileSystemContractTest.java
@@ -6,13 +6,10 @@
  */
 package org.xtreemfs.common.clients.hadoop;
 
-import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FileSystemContractBaseTest;
+import org.apache.hadoop.fs.Hadoop1FileSystemContractBaseTest;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.xtreemfs.common.libxtreemfs.Client;
 import org.xtreemfs.common.libxtreemfs.ClientFactory;
 import org.xtreemfs.common.libxtreemfs.Options;
@@ -20,42 +17,30 @@ import org.xtreemfs.foundation.pbrpc.client.RPCAuthentication;
 import org.xtreemfs.foundation.pbrpc.generatedinterfaces.RPC.UserCredentials;
 
 /**
- * Executes file system contract tests with XtreemFS initialized from
+ * Executes Hadoop 1 file system contract tests with XtreemFS initialized from
  * <code>xtreemfs.defaultVolumeName</code>.
  */
-public class XtreemFSFileSystemContractTest extends FileSystemContractBaseTest {
+public final class XtreemFSHadoop1FileSystemContractTest extends Hadoop1FileSystemContractBaseTest {
 
-    protected final Client client;
+    private final Client client;
 
-    protected final UserCredentials userCredentials;
+    private final UserCredentials userCredentials;
 
-    protected final Path fileSystemPath;
+    private final Path fileSystemPath;
 
-    protected final Path dirPath, mrcPath;
+    private final Path dirPath, mrcPath;
 
-    protected static final String DEFAULT_VOLUME_NAME = "hadoopJUnitTest",
+    private static final String DEFAULT_VOLUME_NAME = "hadoopJUnitTest",
             UNUSED_VOLUME_NAME = DEFAULT_VOLUME_NAME + "_";
 
-    protected final Configuration conf;
-    
-    // whether to set xtreemfs.defaultVolumeName during setUp, defaults to true
-    protected boolean setXtreemFSDefaultVolumeName;
-    
-    // whether to instantiate the file system using FileSystem.get, defaults to true
-    protected boolean useFSFactory;
+    private final Configuration conf;
 
-    public XtreemFSFileSystemContractTest() {
-        this("xtreemfs://localhost:32638", "xtreemfs://localhost:32638",
-                "xtreemfs://localhost:32636");
-    }
+    public XtreemFSHadoop1FileSystemContractTest() {
+        this.fileSystemPath = new Path("xtreemfs://localhost:32638");
+        this.dirPath = new Path("xtreemfs://localhost:32638");
+        this.mrcPath = new Path("xtreemfs://localhost:32636");
 
-    protected XtreemFSFileSystemContractTest(String fileSystemUri,
-            String dirUri, String mrcUri) {
-        this.fileSystemPath = new Path(fileSystemUri);
-        this.dirPath = new Path(dirUri);
-        this.mrcPath = new Path(mrcUri);
-
-        Configuration.addDefaultResource(XtreemFSFileSystemContractTest.class
+        Configuration.addDefaultResource(XtreemFSHadoop1FileSystemContractTest.class
                 .getClassLoader().getResource("core-site.xml").getPath());
         conf = new Configuration();
 
@@ -64,9 +49,6 @@ public class XtreemFSFileSystemContractTest extends FileSystemContractBaseTest {
 
         client = ClientFactory.createClient(ClientFactory.ClientType.NATIVE,
                 dirPath.toUri().getAuthority(), userCredentials, null, new Options());
-        
-        setXtreemFSDefaultVolumeName = true;
-        useFSFactory = true;
     }
 
     @Override
@@ -78,82 +60,15 @@ public class XtreemFSFileSystemContractTest extends FileSystemContractBaseTest {
                 userCredentials, DEFAULT_VOLUME_NAME);
         client.createVolume(mrcPath.toUri().getAuthority(), RPCAuthentication.authNone,
                 userCredentials, UNUSED_VOLUME_NAME);
-        
+
         conf.set("xtreemfs.jni.libraryPath", System.getenv("XTREEMFS")
                 + "/cpp/build");
-        if (setXtreemFSDefaultVolumeName) {
-            conf.set("xtreemfs.defaultVolumeName", DEFAULT_VOLUME_NAME);
-        }
+        conf.set("xtreemfs.defaultVolumeName", DEFAULT_VOLUME_NAME);
+        conf.set("xtreemfs.hadoop.version", "1");
 
-        if (useFSFactory) {
-            fs = FileSystem.get(fileSystemPath.toUri(), conf);
-        } else {
-            fs = new XtreemFSFileSystem();
-            fs.initialize(fileSystemPath.toUri(), conf);
-        }
+        fs = FileSystem.get(fileSystemPath.toUri(), conf);
 
         super.setUp();
-    }
-
-    /**
-     * Tests proper handling of correct URIs, in particular:<br />
-     * <code>
-     * xtreemfs://server:port/volume/path/to/file<br />
-     * xtreemfs://server/volume/path/to/file<br />
-     * xtreemfs:/path/to/file<br />
-     * //server:port/volume/path/to/file<br />
-     * //server/volume/path/to/file<br />
-     * /path/to/file<br />
-     * path/to/file<br />
-     * ./path/to/file<br />
-     * ../path/to/file
-     * </code>
-     *
-     * @throws Exception
-     */
-    public void testFileURIs() throws Exception {
-        String expected = "xtreemfs://" + dirPath.toUri().getAuthority() + "/"
-                + DEFAULT_VOLUME_NAME + "/path/to/file";
-
-        // xtreemfs://localhost:32638/hadoopJUnitTest/path/to/file
-        assertFileCreated(expected, expected);
-
-        // xtreemfs://localhost/hadoopJUnitTest/path/to/file
-        assertFileCreated(
-                "xtreemfs://" + dirPath.toUri().getHost() + "/" + DEFAULT_VOLUME_NAME + "/path/to/file",
-                expected);
-
-        // xtreemfs:/path/to/file
-        assertFileCreated("xtreemfs:/path/to/file", expected);
-
-        // //localhost:32638/hadoopJUnitTest/path/to/file
-        assertFileCreated(
-                "//" + dirPath.toUri().getAuthority() + "/" + DEFAULT_VOLUME_NAME + "/path/to/file",
-                expected);
-
-        // //localhost/hadoopJUnitTest/path/to/file
-        assertFileCreated(
-                "//" + dirPath.toUri().getHost() + "/" + DEFAULT_VOLUME_NAME + "/path/to/file",
-                expected);
-
-        // /path/to/file
-        assertFileCreated("/path/to/file", expected);
-
-        expected = "xtreemfs://" + dirPath.toUri().getAuthority() + "/"
-                + DEFAULT_VOLUME_NAME + "/user/" + System.getProperty("user.name")
-                + "/path/to/file";
-
-        // path/to/file
-        assertFileCreated("path/to/file", expected);
-
-        // ./path/to/file
-        assertFileCreated("./path/to/file", expected);
-
-        expected = "xtreemfs://" + dirPath.toUri().getAuthority() + "/"
-                + DEFAULT_VOLUME_NAME + "/user/path/to/file";
-
-        // ../path/to/file
-        assertFileCreated("../path/to/file", expected);
     }
 
     @Override
@@ -165,13 +80,6 @@ public class XtreemFSFileSystemContractTest extends FileSystemContractBaseTest {
         client.deleteVolume(mrcPath.toUri().getAuthority(), RPCAuthentication.authNone,
                 userCredentials, UNUSED_VOLUME_NAME);
         client.shutdown();
-    }
-
-    protected void assertFileCreated(String path, String expected) throws IOException {
-        FSDataOutputStream file = fs.create(new Path(path));
-        ContractTestUtils.assertIsFile(fs, new Path(expected));
-        ContractTestUtils.assertDeleted(fs, new Path(expected), true);
-        file.close();
     }
 
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -279,7 +279,7 @@ Tests = [
         'name': 'hadoop test',
         'file': 'hadoop_test.sh',
         'VolumeConfigs': ['regular'],
-        'TestSets': [ ]
+        'TestSets': [ 'full' ]
     },
     {
         'name': 'hadoop2 test',

--- a/tests/test_scripts/hadoop2_test.sh
+++ b/tests/test_scripts/hadoop2_test.sh
@@ -118,6 +118,11 @@ for VERSION in $HADOOP_VERSIONS; do
      <value>$XTREEMFS/cpp/build</value>
    </property>
 
+   <property>
+     <name>xtreemfs.hadoop.version</name>
+     <value>$VERSION</value>
+   </property>
+
    </configuration>"
 
    echo $CORE_SITE > $HADOOP_CONF_DIR/core-site.xml

--- a/tests/test_scripts/hadoop_ssl_test.sh
+++ b/tests/test_scripts/hadoop_ssl_test.sh
@@ -109,6 +109,11 @@ for VERSION in $HADOOP_VERSIONS; do
     <value>passphrase</value>
    </property>
 
+   <property>
+     <name>xtreemfs.hadoop.version</name>
+     <value>$VERSION</value>
+   </property>
+
    </configuration>"
 
    echo $CORE_SITE > $HADOOP_PREFIX/conf/core-site.xml

--- a/tests/test_scripts/hadoop_test.sh
+++ b/tests/test_scripts/hadoop_test.sh
@@ -112,6 +112,11 @@ for VERSION in $HADOOP_VERSIONS; do
      <value>$XTREEMFS/cpp/build</value>
    </property>
 
+   <property>
+     <name>xtreemfs.hadoop.version</name>
+     <value>$VERSION</value>
+   </property>
+
    </configuration>"
 
    echo $CORE_SITE > $HADOOP_PREFIX/conf/core-site.xml

--- a/tests/test_scripts/hadoop_test.sh
+++ b/tests/test_scripts/hadoop_test.sh
@@ -48,7 +48,7 @@ for VERSION in $HADOOP_VERSIONS; do
    </property>
 
    <property>
-    <name>fs.defaultFS</name>
+    <name>fs.default.name</name>
     <value>xtreemfs://localhost:32638</value>
     <description>Address for the DIR.</description>
    </property>


### PR DESCRIPTION
This PR introduces compatibility with different Hadoop versions. It is now possible to tell the XtreemFS Hadoop adapter which Hadoop version it is working with using the configuration parameter 'xtreemfs.hadoop.version'. For now only the behavior of 'listStatus(..)' has changed, as this is the only difference between the file system contracts of Hadoop 0.x, 1.x and 2.x. The Hadoop 1 nightly test has been added back to the 'full' test suite, and the 'fs.default.name' parameter is used for configuring Hadoop 1 again because it does not know about 'fs.defaultFS'. The FileSystemContractBaseTest for Hadoop 1 has been copied from https://github.com/apache/hadoop/blob/branch-1/src/test/org/apache/hadoop/fs/FileSystemContractBaseTest.java as that seems to be the most recent 1.x code base.