### PR TITLE
Deployment from Tags, SSL Logging + Bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - TEST_SUITE=travis-cpp       BUILD_CLIENT_TESTS=true  SKIP_JNI=true
     - TEST_SUITE=travis-valgrind  BUILD_CLIENT_TESTS=true  SKIP_JNI=true
     - TEST_SUITE=travis-contrib
+    - TEST_SUITE=travis-deploy
 
 sudo: false
 
@@ -26,6 +27,7 @@ addons:
       - python
       - valgrind
       - net-tools
+      - openjdk-7-jdk
 
 before_script:
   - TEST_DIR="/tmp/xtreemfs_xtestenv"
@@ -33,9 +35,13 @@ before_script:
   - XTREEMFS_DIST_DIR="xtreemfs-${TRAVIS_TAG}-$(lsb_release -c -s)-dist"
   - XTREEMFS_DIST_TAR="${XTREEMFS_DIST_DIR}.tar.gz"
 
-script:
-  - make client server hadoop-client -j2
-  - ./tests/xtestenv --clean-test-dir -x $XTREEMFS_DIR -t $TEST_DIR -c $XTREEMFS_DIR/tests/test_config.py -p $TEST_SUITE
+script: |
+  if [[ $TEST_SUITE = "travis-deploy" ]]; then
+    true
+  else
+    make client server hadoop-client -j2
+    ./tests/xtestenv --clean-test-dir -x $XTREEMFS_DIR -t $TEST_DIR -c $XTREEMFS_DIR/tests/test_config.py -p $TEST_SUITE
+  fi
 
 after_failure:
   - JUNIT_RESULT=`./contrib/travis/parse_results.py $TEST_DIR/result.json 'JUnit tests'`
@@ -63,3 +69,4 @@ deploy:
   on:
     repo: xtreemfs/xtreemfs
     tags: true
+    condition: "$TEST_SUITE = travis-deploy"

--- a/cpp/src/rpc/client_connection.cpp
+++ b/cpp/src/rpc/client_connection.cpp
@@ -265,7 +265,16 @@ void ClientConnection::PostConnect(const boost::system::error_code& err,
       string ssl_error_info;
 #ifdef HAS_OPENSSL
       if (err.category() == asio::error::ssl_category) {
-        ssl_error_info = ERR_error_string(ERR_get_error(), NULL);
+        ostringstream oss;
+        oss
+          << "Boost error message: '" << err.message() << "' (value: '" << err.value() << "')"
+          << ", OpenSSL library number: '" << ERR_GET_LIB(err.value()) << "'"
+          << ", OpenSSL function code: '" << ERR_GET_FUNC(err.value()) << "'"
+          << ", OpenSSL reason code: '" << ERR_GET_REASON(err.value()) << "'";
+        char buf[512];
+        ERR_error_string_n(err.value(), buf, sizeof(buf));
+        oss << ", OpenSSL error string: '" << buf << "'";
+        ssl_error_info = oss.str();
       }
 #endif  // HAS_OPENSSL
       SendError(POSIX_ERROR_EIO,

--- a/java/servers/test/org/xtreemfs/test/mrc/OSDPolicyTest.java
+++ b/java/servers/test/org/xtreemfs/test/mrc/OSDPolicyTest.java
@@ -422,7 +422,7 @@ public class OSDPolicyTest {
                 .setName("osd5").setVersion(1).setUuid("osd5").setData(getDefaultServiceDataMap()));
         
         UUIDResolver.addTestMapping("osd1", "xtreemfs1.zib.de", 2222, false);
-        UUIDResolver.addTestMapping("osd2", "www.heise.de", 2222, false);
+        UUIDResolver.addTestMapping("osd2", "www.berlin.de", 2222, false);
         UUIDResolver.addTestMapping("osd3", "xtreemfs.zib.de", 2222, false);
         UUIDResolver.addTestMapping("osd4", "csr-pc29.zib.de", 2222, false);
         UUIDResolver.addTestMapping("osd5", "download.xtreemfs.com", 2222, false);
@@ -436,7 +436,7 @@ public class OSDPolicyTest {
         assertEquals("osd2", sortedList.getServices(3).getUuid());
         assertEquals("osd5", sortedList.getServices(4).getUuid());
         
-        clientAddr = InetAddress.getByName("www.heise.de");
+        clientAddr = InetAddress.getByName("www.berlin.de");
         sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(osds.getServicesList()),
             clientAddr, null, null, Integer.MAX_VALUE);
         
@@ -461,7 +461,7 @@ public class OSDPolicyTest {
                 .setName("osd5").setVersion(1).setUuid("osd5").setData(getDefaultServiceDataMap()));
         
         UUIDResolver.addTestMapping("osd1", "bla.xtreemfs.zib.de", 2222, false);
-        UUIDResolver.addTestMapping("osd2", "www.heise.de", 2222, false);
+        UUIDResolver.addTestMapping("osd2", "www.berlin.de", 2222, false);
         UUIDResolver.addTestMapping("osd3", "blub.xtreemfs.zib.de", 2222, false);
         UUIDResolver.addTestMapping("osd4", "csr-pc29.zib.de", 2222, false);
         UUIDResolver.addTestMapping("osd5", "download.xtreemfs.com", 2222, false);
@@ -482,7 +482,7 @@ public class OSDPolicyTest {
             clientAddr, null, null, 4);
         assertEquals(0, sortedList.getServicesCount());
         
-        clientAddr = InetAddress.getByName("www.heise.de");
+        clientAddr = InetAddress.getByName("www.berlin.de");
         sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(osds.getServicesList()),
             clientAddr, null, null, 1);
         assertEquals(1, sortedList.getServicesCount());
@@ -544,7 +544,7 @@ public class OSDPolicyTest {
                 .setVersion(1).setUuid("osd5").setName("osd5").setData(sdm));
         
         UUIDResolver.addTestMapping("osd1", "bla.xtreemfs.zib.de", 2222, false);
-        UUIDResolver.addTestMapping("osd2", "www.heise.de", 2222, false);
+        UUIDResolver.addTestMapping("osd2", "www.berlin.de", 2222, false);
         UUIDResolver.addTestMapping("osd3", "blub.xtreemfs.zib.de", 2222, false);
         UUIDResolver.addTestMapping("osd4", "csr-pc29.zib.de", 2222, false);
         UUIDResolver.addTestMapping("osd5", "download.xtreemfs.com", 2222, false);

--- a/tests/config_parser.py
+++ b/tests/config_parser.py
@@ -103,7 +103,10 @@ class TestConfig:
         activeVolumeConfigs = dict()
         activeTests = list()
 
-        self.__curren_test_set = self.__testSets[self.__testSetName]
+        try:
+            self.__curren_test_set = self.__testSets[self.__testSetName]
+        except KeyError:
+            raise Exception('Invalid TestSet: "' + self.__testSetName + '"')
 
         if self.__testSetName.startswith(MANUAL_TEST_SET_NAME):
             #skip this for manual set-ups.

--- a/tests/configs/dirconfig_no_ssl.test
+++ b/tests/configs/dirconfig_no_ssl.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_ignore_errors.test
+++ b/tests/configs/dirconfig_ssl_ignore_errors.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_long_chain.test
+++ b/tests/configs/dirconfig_ssl_long_chain.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_no_verification.test
+++ b/tests/configs/dirconfig_ssl_no_verification.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_short_chain.test
+++ b/tests/configs/dirconfig_ssl_short_chain.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_version.test
+++ b/tests/configs/dirconfig_ssl_version.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_version_sslv3.test
+++ b/tests/configs/dirconfig_ssl_version_sslv3.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_version_tlsv1.test
+++ b/tests/configs/dirconfig_ssl_version_tlsv1.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_version_tlsv11.test
+++ b/tests/configs/dirconfig_ssl_version_tlsv11.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/dirconfig_ssl_version_tlsv12.test
+++ b/tests/configs/dirconfig_ssl_version_tlsv12.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_no_ssl.test
+++ b/tests/configs/mrcconfig_no_ssl.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_ignore_errors.test
+++ b/tests/configs/mrcconfig_ssl_ignore_errors.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_long_chain.test
+++ b/tests/configs/mrcconfig_ssl_long_chain.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_no_verification.test
+++ b/tests/configs/mrcconfig_ssl_no_verification.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_short_chain.test
+++ b/tests/configs/mrcconfig_ssl_short_chain.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_version.test
+++ b/tests/configs/mrcconfig_ssl_version.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_version_sslv3.test
+++ b/tests/configs/mrcconfig_ssl_version_sslv3.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_version_tlsv1.test
+++ b/tests/configs/mrcconfig_ssl_version_tlsv1.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_version_tlsv11.test
+++ b/tests/configs/mrcconfig_ssl_version_tlsv11.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/mrcconfig_ssl_version_tlsv12.test
+++ b/tests/configs/mrcconfig_ssl_version_tlsv12.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_no_ssl.test
+++ b/tests/configs/osdconfig_no_ssl.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_ignore_errors.test
+++ b/tests/configs/osdconfig_ssl_ignore_errors.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_long_chain.test
+++ b/tests/configs/osdconfig_ssl_long_chain.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_no_verification.test
+++ b/tests/configs/osdconfig_ssl_no_verification.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_short_chain.test
+++ b/tests/configs/osdconfig_ssl_short_chain.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_version.test
+++ b/tests/configs/osdconfig_ssl_version.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_version_sslv3.test
+++ b/tests/configs/osdconfig_ssl_version_sslv3.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_version_tlsv1.test
+++ b/tests/configs/osdconfig_ssl_version_tlsv1.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_version_tlsv11.test
+++ b/tests/configs/osdconfig_ssl_version_tlsv11.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/configs/osdconfig_ssl_version_tlsv12.test
+++ b/tests/configs/osdconfig_ssl_version_tlsv12.test
@@ -7,7 +7,7 @@
 # 5: notice
 # 6: info (default)
 # 7: debug
-debug.level = 6
+debug.level = 7
 
 # optional debug categories - a space or comma-separated list of log message categories
 # all (default) - enable logging for all categories

--- a/tests/test_scripts/cpp_unit_tests.sh
+++ b/tests/test_scripts/cpp_unit_tests.sh
@@ -19,4 +19,4 @@ export XTREEMFS_MRC_URL="$3"
 export XTREEMFS_TEST_DIR="$4"
 
 cd cpp/build
-make test
+make test ARGS=-VV

--- a/tests/xtestenv
+++ b/tests/xtestenv
@@ -546,14 +546,19 @@ if __name__ == "__main__":
 
         print 'Executing test set :', positional_args[0]
 
-        testEnv = TestEnvironment(options.config_file_path,
-                                  positional_args[0],
-                                  options.volume,
-                                  options.xtreemfs_dir,
-                                  options.test_dir,
-                                  options.debug_level,
-                                  options.storage_threads,
-                                  options.progress)
+        try:
+            testEnv = TestEnvironment(options.config_file_path,
+                                      positional_args[0],
+                                      options.volume,
+                                      options.xtreemfs_dir,
+                                      options.test_dir,
+                                      options.debug_level,
+                                      options.storage_threads,
+                                      options.progress)
+        except Exception as e:
+            print "Exception during creation of Test Environment: {0}, exiting.".format(e.args[0])
+            sys.exit(1)
+
         testEnv.start()
         try:
             failed = testEnv.runTests()


### PR DESCRIPTION
This PR introduces the ability to deploy an XtreemFS binary release to GitHub Releases by pushing a tag.

Furthermore, more useful SSL logging is introduced.

Logging during C++ testing is set to DEBUG, and logs are printed in full during test failures. Continuous logging ensures that Travis does not terminate the build prematurely.

Explicitly specifying openjdk-7-jdk as a package ensures the latest version, thereby fixing failing C++ SSL tests.