### PR TITLE
Command Line Parsing Improvements

### DIFF
--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/utils.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/utils.java
@@ -9,6 +9,7 @@
 package org.xtreemfs.utils;
 
 import java.io.BufferedReader;
+import java.io.Console;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -16,9 +17,9 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
-import java.util.Map.Entry;
 
 import org.xtreemfs.foundation.util.CLIParser.CliOption;
 
@@ -166,7 +167,7 @@ public class utils {
             new CliOption(CliOption.OPTIONTYPE.SWITCH, "show usage information", ""));
         if (adminPass)
             options.put(OPTION_ADMIN_PASS, new CliOption(CliOption.OPTIONTYPE.STRING,
-                "administrator password to authorize operation", "<passphrase>"));
+                "administrator password to authorize operation. Set to '-' to prompt for the passphrase.", "<passphrase>"));
         
         return options;
     }
@@ -210,6 +211,26 @@ public class utils {
             System.out.println(line.toString());
             
             previous = next.getKey();
+        }
+    }
+
+    public static String readPassword(String format, Object... args) {
+        Console console = System.console();
+        if (console != null) {
+            return new String(console.readPassword(format, args));
+        } else {
+            // non-interactive console, e.g. from a cron
+            // this will not hide the typed characters though,
+            // so use as fallback only.
+            System.out.println(String.format(format, args));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+            try {
+                String password = reader.readLine();
+                reader.close();
+                return password;
+            } catch (IOException e) {
+                return null;
+            }
         }
     }
 }

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_benchmark/CLIOptions.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_benchmark/CLIOptions.java
@@ -286,8 +286,12 @@ class CLIOptions {
 
     private void setOSDPassword() {
         String osdPassword = options.get(utils.OPTION_ADMIN_PASS).stringValue;
-        if (null != osdPassword)
+        if (null != osdPassword) {
+            if (osdPassword.equals("-")) {
+                osdPassword = utils.readPassword("Enter admin password: ");
+            }
             builder.setAdminPassword(osdPassword);
+        }
     }
 
     private void setSSLOptions() throws IOException {

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_chstatus.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_chstatus.java
@@ -74,12 +74,12 @@ public class xtfs_chstatus {
                     String serviceCredsFile = options.get(utils.OPTION_USER_CREDS_FILE).stringValue;
                     String serviceCredsPass = options.get(utils.OPTION_USER_CREDS_PASS).stringValue;
                     if(serviceCredsPass != null && serviceCredsPass.equals("-")) {
-                    	serviceCredsPass = new String(System.console().readPassword("Enter credentials password: "));
+                    	serviceCredsPass = utils.readPassword("Enter credentials password: ");
                     }
                     String trustedCAsFile = options.get(utils.OPTION_TRUSTSTORE_FILE).stringValue;
                     String trustedCAsPass = options.get(utils.OPTION_TRUSTSTORE_PASS).stringValue;
                     if(trustedCAsPass != null && trustedCAsPass.equals("-")) {
-                    	trustedCAsPass = new String(System.console().readPassword("Enter credentials password: "));
+                    	trustedCAsPass = utils.readPassword("Enter credentials password: ");
                     }
                     String sslProtocolString = options.get(utils.OPTION_SSL_PROTOCOL).stringValue;
                     if (dirURL.contains(Schemes.SCHEME_PBRPCG + "://")) {

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_cleanup_osd.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_cleanup_osd.java
@@ -101,6 +101,9 @@ public class xtfs_cleanup_osd {
 
         password = (options.get(utils.OPTION_ADMIN_PASS).stringValue != null) ? options
                 .get(utils.OPTION_ADMIN_PASS).stringValue : "";
+        if (password.equals("-")) {
+            password = utils.readPassword("Enter admin password: ");
+        }
 
         SSLOptions sslOptions = null;
         String[] dirAddrs = null;
@@ -125,12 +128,12 @@ public class xtfs_cleanup_osd {
                     String serviceCredsFile = options.get(utils.OPTION_USER_CREDS_FILE).stringValue;
                     String serviceCredsPass = options.get(utils.OPTION_USER_CREDS_PASS).stringValue;
                     if(serviceCredsPass != null && serviceCredsPass.equals("-")) {
-                    	serviceCredsPass = new String(System.console().readPassword("Enter credentials password: "));
+                    	serviceCredsPass = utils.readPassword("Enter credentials password: ");
                     }
                     String trustedCAsFile = options.get(utils.OPTION_TRUSTSTORE_FILE).stringValue;
                     String trustedCAsPass = options.get(utils.OPTION_TRUSTSTORE_PASS).stringValue;
                     if(trustedCAsPass != null && trustedCAsPass.equals("-")) {
-                    	trustedCAsPass = new String(System.console().readPassword("Enter trust store password: "));
+                    	trustedCAsPass = utils.readPassword("Enter trust store password: ");
                     }
                     String sslProtocolString = options.get(utils.OPTION_SSL_PROTOCOL).stringValue;
                     if (dirURL.contains(Schemes.SCHEME_PBRPCG + "://")) {

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_mrcdbtool.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_mrcdbtool.java
@@ -92,12 +92,12 @@ public class xtfs_mrcdbtool {
         CliOption c = options.get(utils.OPTION_USER_CREDS_FILE);
         String cp = options.get(utils.OPTION_USER_CREDS_PASS).stringValue;
         if(cp != null && cp.equals("-")) {
-        	cp = new String(System.console().readPassword("Enter credentials password: "));
+            cp = utils.readPassword("Enter credentials password: ");
         }
         CliOption t = options.get(utils.OPTION_TRUSTSTORE_FILE);
         String tp = options.get(utils.OPTION_TRUSTSTORE_PASS).stringValue;
         if(tp != null && tp.equals("-")) {
-        	tp = new String(System.console().readPassword("Enter trust store password: "));
+            tp = utils.readPassword("Enter trust store password: ");
         }
         
         String sslProtocolString = options.get(utils.OPTION_SSL_PROTOCOL).stringValue;
@@ -134,9 +134,14 @@ public class xtfs_mrcdbtool {
             MRCServiceClient client = new MRCServiceClient(rpcClient, new InetSocketAddress(host, port));
             
             Auth passwdAuth = RPCAuthentication.authNone;
-            if (options.get(utils.OPTION_ADMIN_PASS).stringValue != null)
+            String adminPass = options.get(utils.OPTION_ADMIN_PASS).stringValue;
+            if (adminPass != null) {
+                if (adminPass.equals("-")) {
+                    adminPass = utils.readPassword("Enter admin password: ");
+                }
                 passwdAuth = Auth.newBuilder().setAuthType(AuthType.AUTH_PASSWORD).setAuthPasswd(
-                    AuthPassword.newBuilder().setPassword(options.get(utils.OPTION_ADMIN_PASS).stringValue)).build();
+                    AuthPassword.newBuilder().setPassword(adminPass)).build();
+            }
             
             if (op.equals("dump")) {
                 RPCResponse<?> r = null;

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_remove_osd.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_remove_osd.java
@@ -94,6 +94,9 @@ public class xtfs_remove_osd {
             boolean shutdown = options.get("s").switchValue;
             String password = (options.get(utils.OPTION_ADMIN_PASS).stringValue != null) ? options
                     .get(utils.OPTION_ADMIN_PASS).stringValue : "";
+            if (password.equals("-")) {
+                password = utils.readPassword("Enter admin password: ");
+            }
 
             String[] dirURLs = (options.get("dir").stringValue != null) ? options.get("dir").stringValue
                     .split(",") : null;
@@ -122,12 +125,12 @@ public class xtfs_remove_osd {
                         String serviceCredsFile = options.get(utils.OPTION_USER_CREDS_FILE).stringValue;
                         String serviceCredsPass = options.get(utils.OPTION_USER_CREDS_PASS).stringValue;
                         if(serviceCredsPass != null && serviceCredsPass.equals("-")) {
-                        	serviceCredsPass = new String(System.console().readPassword("Enter credentials password: "));
+                        	serviceCredsPass = utils.readPassword("Enter credentials password: ");
                         }
                         String trustedCAsFile = options.get(utils.OPTION_TRUSTSTORE_FILE).stringValue;
                         String trustedCAsPass = options.get(utils.OPTION_TRUSTSTORE_PASS).stringValue;
                         if(trustedCAsPass != null && trustedCAsPass.equals("-")) {
-                        	trustedCAsPass = new String(System.console().readPassword("Enter trust store password: "));
+                        	trustedCAsPass = utils.readPassword("Enter trust store password: ");
                         }
                         String sslProtocolString = options.get(utils.OPTION_SSL_PROTOCOL).stringValue;
                         if (dirURL.contains(Schemes.SCHEME_PBRPCG + "://")) {

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_scrub/xtfs_scrub.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/utils/xtfs_scrub/xtfs_scrub.java
@@ -375,12 +375,12 @@ public class xtfs_scrub {
                     String serviceCredsFile = options.get(utils.OPTION_USER_CREDS_FILE).stringValue;
                     String serviceCredsPass = options.get(utils.OPTION_USER_CREDS_PASS).stringValue;
                     if(serviceCredsPass != null && serviceCredsPass.equals("-")) {
-                    	serviceCredsPass = new String(System.console().readPassword("Enter credentials password: "));
+                    	serviceCredsPass = utils.readPassword("Enter credentials password: ");
                     }
                     String trustedCAsFile = options.get(utils.OPTION_TRUSTSTORE_FILE).stringValue;
                     String trustedCAsPass = options.get(utils.OPTION_TRUSTSTORE_PASS).stringValue;
                     if(trustedCAsPass != null && trustedCAsPass.equals("-")) {
-                    	trustedCAsPass = new String(System.console().readPassword("Enter trust store password: "));
+                    	trustedCAsPass = utils.readPassword("Enter trust store password: ");
                     }
                     String sslProtocolString = options.get(utils.OPTION_SSL_PROTOCOL).stringValue;
                     if (dirURL.contains(Schemes.SCHEME_PBRPCG + "://")) {


### PR DESCRIPTION
This PR makes the `admin_password` command line option "promptable", i.e. if a dash (-) is passed as a password, then the password will be prompted. Furthermore, to add support for non-interactive shells, a fallback to `System.in` has been added to allow piping of prompted passwords using `<`.