### PR TITLE
Extended OSDSelectionPolicy interface

### DIFF
--- a/cpp/src/xtfsutil/xtfsutil.cpp
+++ b/cpp/src/xtfsutil/xtfsutil.cpp
@@ -987,7 +987,13 @@ bool SetOSP(const string& xctl_file,
           + ","
           + boost::lexical_cast<string>(
               xtreemfs::pbrpc::OSD_SELECTION_POLICY_PREFERRED_UUID);
-  }  else {
+  } else if (policy_uc == "PREFIX") {
+      request["policy"] = boost::lexical_cast<string>(
+          xtreemfs::pbrpc::OSD_SELECTION_POLICY_FILTER_DEFAULT)
+          + ","
+          + boost::lexical_cast<string>(
+              xtreemfs::pbrpc::OSD_SELECTION_POLICY_FILENAME_PREFIX);
+  } else {
     request["policy"] = policy;
   }
 

--- a/interface/xtreemfs/GlobalTypes.proto
+++ b/interface/xtreemfs/GlobalTypes.proto
@@ -57,6 +57,9 @@ enum OSDSelectionPolicyType {
     // Set a preferred OSD to be first in the list, 
     // the other OSDs are appended in random order.
     OSD_SELECTION_POLICY_PREFERRED_UUID = 1003;
+    // Select an OSD based on the path of the handled file
+    // and user selected prefixes.
+    OSD_SELECTION_POLICY_FILENAME_PREFIX = 1004;
     // Groups OSDs according to their location in the
     // datacenter map.
     OSD_SELECTION_POLICY_GROUP_DCMAP = 2000;

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/MRCPolicyContainer.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/MRCPolicyContainer.java
@@ -21,6 +21,7 @@ import org.xtreemfs.mrc.ac.POSIXFileAccessPolicy;
 import org.xtreemfs.mrc.ac.VolumeACLFileAccessPolicy;
 import org.xtreemfs.mrc.ac.YesToAnyoneFileAccessPolicy;
 import org.xtreemfs.mrc.database.VolumeManager;
+import org.xtreemfs.mrc.osdselection.FileNamePrefixPolicy;
 import org.xtreemfs.mrc.osdselection.FilterDefaultPolicy;
 import org.xtreemfs.mrc.osdselection.FilterFQDNPolicy;
 import org.xtreemfs.mrc.osdselection.FilterUUIDPolicy;
@@ -47,7 +48,7 @@ public class MRCPolicyContainer extends PolicyContainer {
             GroupDCMapPolicy.class.getName(), GroupFQDNPolicy.class.getName(), SortDCMapPolicy.class.getName(),
             SortFQDNPolicy.class.getName(), SortRandomPolicy.class.getName(), SortVivaldiPolicy.class.getName(),
             SortUUIDPolicy.class.getName(), SortReversePolicy.class.getName(), SortHostRoundRobinPolicy.class.getName(),
-            PreferredUUIDPolicy.class.getName()
+            PreferredUUIDPolicy.class.getName(), FileNamePrefixPolicy.class.getName()
     };
     
     private final MRCConfig             config;

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/GetSuitableOSDsOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/GetSuitableOSDsOperation.java
@@ -84,11 +84,16 @@ public class GetSuitableOSDsOperation extends MRCOperation {
         if (file.isDirectory())
             throw new UserException(POSIXErrno.POSIX_ERROR_EISDIR,
                     "xtreemfs_get_suitable_osds must be invoked on a file");
+
+        String path = null;
+        if (rqArgs.hasPath()) {
+            path = rqArgs.getPath();
+        }
         
         // retrieve the set of OSDs for the new replica
         ServiceSet.Builder usableOSDs = master.getOSDStatusManager().getUsableOSDs(volumeId,
             ((InetSocketAddress) rq.getRPCRequest().getSenderAddress()).getAddress(), null,
-            file.getXLocList(), rqArgs.getNumOsds());
+            file.getXLocList(), rqArgs.getNumOsds(), path);
         
         xtreemfs_get_suitable_osdsResponse.Builder resp = xtreemfs_get_suitable_osdsResponse.newBuilder();
         for (int i = 0; i < usableOSDs.getServicesCount(); i++)

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/GetSuitableOSDsOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/GetSuitableOSDsOperation.java
@@ -86,8 +86,8 @@ public class GetSuitableOSDsOperation extends MRCOperation {
                     "xtreemfs_get_suitable_osds must be invoked on a file");
 
         String path = null;
-        if (rqArgs.hasPath()) {
-            path = rqArgs.getPath();
+        if (rqArgs.hasVolumeName() && rqArgs.hasPath()) {
+            path = new Path(rqArgs.getVolumeName(), rqArgs.getPath()).toString();
         }
         
         // retrieve the set of OSDs for the new replica

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/GetXLocSetOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/GetXLocSetOperation.java
@@ -119,12 +119,17 @@ public class GetXLocSetOperation extends MRCOperation {
         XLocList xLocList = file.getXLocList();
         assert (xLocList != null);
         XLocSet.Builder xLocSetBuilder = Converter.xLocListToXLocSet(xLocList);
+
+        String path = null;
+        if (rqArgs.hasPath()) {
+            path = rqArgs.getPath();
+        }
         
         // Sort the XLocSet according to the policy.
         List<Replica> sortedReplList = master.getOSDStatusManager()
                 .getSortedReplicaList(volume.getId(),
                         ((InetSocketAddress) rq.getRPCRequest().getSenderAddress()).getAddress(),
-                        rqArgs.getCoordinates(), xLocSetBuilder.getReplicasList(), xLocList)
+                        rqArgs.getCoordinates(), xLocSetBuilder.getReplicasList(), xLocList, path)
                 .getReplicasList();
         xLocSetBuilder.clearReplicas();
         xLocSetBuilder.addAllReplicas(sortedReplList);

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/GetXLocSetOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/GetXLocSetOperation.java
@@ -121,8 +121,8 @@ public class GetXLocSetOperation extends MRCOperation {
         XLocSet.Builder xLocSetBuilder = Converter.xLocListToXLocSet(xLocList);
 
         String path = null;
-        if (rqArgs.hasPath()) {
-            path = rqArgs.getPath();
+        if (rqArgs.hasVolumeName() && rqArgs.hasPath()) {
+            path = new Path(rqArgs.getVolumeName(), rqArgs.getPath()).toString();
         }
         
         // Sort the XLocSet according to the policy.

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/OpenOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/OpenOperation.java
@@ -75,10 +75,10 @@ public class OpenOperation extends MRCOperation {
         final VolumeManager vMan = master.getVolumeManager();
         final FileAccessManager faMan = master.getFileAccessManager();
         
-        Path p = new Path(rqArgs.getVolumeName(), rqArgs.getPath());
+        Path path = new Path(rqArgs.getVolumeName(), rqArgs.getPath());
         
-        StorageManager sMan = vMan.getStorageManagerByName(p.getComp(0));
-        PathResolver res = new PathResolver(sMan, p);
+        StorageManager sMan = vMan.getStorageManagerByName(path.getComp(0));
+        PathResolver res = new PathResolver(sMan, path);
         VolumeInfo volume = sMan.getVolumeInfo();
         
         // check whether the path prefix is searchable
@@ -231,7 +231,7 @@ public class OpenOperation extends MRCOperation {
                 // create a replica with the default striping policy together
                 // with a set of feasible OSDs from the OSD status manager
                 XLoc replica = MRCHelper.createReplica(null, sMan, master.getOSDStatusManager(), volume, res
-                        .getParentDirId(), p.toString(), ((InetSocketAddress) rq.getRPCRequest()
+                        .getParentDirId(), path.toString(), ((InetSocketAddress) rq.getRPCRequest()
                         .getSenderAddress()).getAddress(), rqArgs.getCoordinates(), xLocList, 0);
                 
                 // integrate the new replica in the XLoc list
@@ -266,7 +266,7 @@ public class OpenOperation extends MRCOperation {
                     // together
                     // with a set of feasible OSDs from the OSD status manager
                     XLoc replica = MRCHelper.createReplica(null, sMan, master.getOSDStatusManager(), volume,
-                        res.getParentDirId(), p.toString(), ((InetSocketAddress) rq.getRPCRequest()
+                        res.getParentDirId(), path.toString(), ((InetSocketAddress) rq.getRPCRequest()
                                 .getSenderAddress()).getAddress(), rqArgs.getCoordinates(), xLocList,
                         defaultReplPolicy != null ? defaultReplPolicy.getFlags() : 0);
                     
@@ -304,7 +304,7 @@ public class OpenOperation extends MRCOperation {
         // re-order the replica list, based on the replica selection policy
         List<Replica> sortedReplList = master.getOSDStatusManager().getSortedReplicaList(volume.getId(),
             ((InetSocketAddress) rq.getRPCRequest().getSenderAddress()).getAddress(),
-            rqArgs.getCoordinates(), xLocSet.getReplicasList(), xLocList).getReplicasList();
+            rqArgs.getCoordinates(), xLocSet.getReplicasList(), xLocList, path.toString()).getReplicasList();
         xLocSet.clearReplicas();
         xLocSet.addAllReplicas(sortedReplList);
         xLocSet.setReadOnlyFileSize(file.getSize());

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FileNamePrefixPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FileNamePrefixPolicy.java
@@ -1,0 +1,97 @@
+package org.xtreemfs.mrc.osdselection;
+
+import org.xtreemfs.common.uuids.ServiceUUID;
+import org.xtreemfs.mrc.metadata.XLocList;
+import org.xtreemfs.pbrpc.generatedinterfaces.DIR;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * OSDSelectionPolicy that allows to choose an OSD based on the path of the
+ * currently handled file.
+ */
+public class FileNamePrefixPolicy implements OSDSelectionPolicy {
+
+    public static final short POLICY_ID = (short) GlobalTypes
+            .OSDSelectionPolicyType
+            .OSD_SELECTION_POLICY_FILENAME_PREFIX
+            .getNumber();
+
+    /*
+     identifier for setting prefixes and OSD ids
+    */
+    private static final String attributeKeyString = "filenamePrefix";
+
+    /*
+      prefixes with an explicit OSD
+     */
+    private HashMap<String, String> prefixToOSDMap =
+            new HashMap<String, String>();
+
+    @Override
+    public DIR.ServiceSet.Builder getOSDs(DIR.ServiceSet.Builder allOSDs,
+                                          InetAddress clientIP,
+                                          GlobalTypes.VivaldiCoordinates
+                                                  clientCoords,
+                                          XLocList currentXLoc,
+                                          int numOSDs,
+                                          String path) {
+
+        List<DIR.Service> allServices = allOSDs.getServicesList();
+        List<DIR.Service> returnList = new LinkedList<DIR.Service>();
+
+        if (!this.prefixToOSDMap.isEmpty()) {
+            int prefixLength = path.lastIndexOf("/");
+            String filePrefix = path.substring(0, prefixLength);
+
+            // check whether the prefix map has an entry for the file,
+            // and if yes, whether the corresponding OSD exists
+            for (String prefix : this.prefixToOSDMap.keySet()) {
+                // maybe this is not strict enough?
+                if (prefix.endsWith(filePrefix) || filePrefix.endsWith(prefix)) {
+                    for (DIR.Service osd : allServices) {
+                        String currentUUID =
+                                new ServiceUUID(osd.getUuid()).toString();
+                        if (currentUUID.equals(this.prefixToOSDMap.get(prefix))) {
+                            returnList.add(osd);
+                            break;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        if (returnList.isEmpty()) {
+            returnList.addAll(allServices);
+        }
+
+        return DIR.ServiceSet.newBuilder().addAllServices(returnList);
+    }
+
+    @Override
+    public DIR.ServiceSet.Builder getOSDs(DIR.ServiceSet.Builder allOSDs) {
+        return allOSDs;
+    }
+
+    @Override
+    public void setAttribute(String key, String value) {
+        if (key.equals(attributeKeyString)) {
+            String command[] = value.split(" ");
+            if (command.length == 3 && command[0].equals("add")) {
+                while (command[1].charAt(command[1].length() - 1) == '/') {
+                    command[1] = command[1].substring(0, command[1].length() - 1);
+                }
+                this.prefixToOSDMap.put(command[1], command[2]);
+            } else if (command.length >= 2 && command[0].equals("remove")) {
+                this.prefixToOSDMap.remove(command[1]);
+            } else if (command.length == 1 && command[0].equals("clear")) {
+                this.prefixToOSDMap.clear();
+            }
+        }
+    }
+}

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FileNamePrefixPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FileNamePrefixPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011 by Jan Stender, Bjoern Kolbeck,
+ * Copyright (c) 2017 by Felix Seibert,
  *               Zuse Institute Berlin
  *
  * Licensed under the BSD License, see LICENSE file for details.

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FilterDefaultPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FilterDefaultPolicy.java
@@ -57,8 +57,12 @@ public class FilterDefaultPolicy implements OSDSelectionPolicy {
     private HashMap<String, String> customNotFilter     = new HashMap<String, String>();
     
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress clientIP,
-            VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
         
         if (allOSDs == null)
             return null;

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FilterFQDNPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FilterFQDNPolicy.java
@@ -46,8 +46,12 @@ public class FilterFQDNPolicy implements OSDSelectionPolicy {
     }
     
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress clientIP, VivaldiCoordinates clientCoords,
-        XLocList currentXLoc, int numOSDs) {
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
         return getOSDs(allOSDs);
     }
     

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FilterUUIDPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/FilterUUIDPolicy.java
@@ -51,7 +51,9 @@ public class FilterUUIDPolicy implements OSDSelectionPolicy {
     public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
                                       InetAddress clientIP,
                                       VivaldiCoordinates clientCoords,
-                                      XLocList currentXLoc, int numOSDs) {
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
         return getOSDs(allOSDs);
     }
 

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/GroupDCMapPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/GroupDCMapPolicy.java
@@ -43,8 +43,12 @@ public class GroupDCMapPolicy extends DCMapPolicyBase {
     }
     
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress clientIP,
-        VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
         
         allOSDs = getOSDs(allOSDs);
         

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/GroupFQDNPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/GroupFQDNPolicy.java
@@ -18,7 +18,8 @@ import org.xtreemfs.foundation.logging.Logging;
 import org.xtreemfs.mrc.metadata.XLocList;
 import org.xtreemfs.pbrpc.generatedinterfaces.DIR.Service;
 import org.xtreemfs.pbrpc.generatedinterfaces.DIR.ServiceSet;
-import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.OSDSelectionPolicyType;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes
+        .OSDSelectionPolicyType;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.VivaldiCoordinates;
 
 /**
@@ -26,58 +27,83 @@ import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.VivaldiCoordinates;
  * of the fully qualified distinguished server names. The selection will be
  * restricted to OSDs that are located in the same domain. If multiple such
  * possible subgroups exist, the one closest to the client will be returned.
- * 
+ *
  * @author bjko, stender
  */
 public class GroupFQDNPolicy extends FQDNPolicyBase {
-    
-    public static final short POLICY_ID = (short) OSDSelectionPolicyType.OSD_SELECTION_POLICY_GROUP_FQDN
-                                                .getNumber();
-    
+
+    public static final short POLICY_ID = (short) OSDSelectionPolicyType
+            .OSD_SELECTION_POLICY_GROUP_FQDN
+            .getNumber();
+
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, final InetAddress clientIP,
-        VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
-        
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      final InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
+
         if (allOSDs == null)
             return null;
-        
+
         // sort the list by their FQDN distance to the client
-        allOSDs = PolicyHelper.sortServiceSet(allOSDs, new Comparator<Service>() {
-            public int compare(Service o1, Service o2) {
-                
-                try {
-                    final String host1 = new ServiceUUID(o1.getUuid()).getAddress().getHostName();
-                    final String host2 = new ServiceUUID(o2.getUuid()).getAddress().getHostName();
-                    
-                    return getMatch(host2, clientIP.getHostName()) - getMatch(host1, clientIP.getHostName());
-                    
-                } catch (UnknownUUIDException exc) {
-                    Logging.logError(Logging.LEVEL_ERROR, this, exc);
-                    return 0;
-                }
-            }
-        });
-        
+        allOSDs = PolicyHelper.sortServiceSet(allOSDs, new
+                Comparator<Service>() {
+                    public int compare(Service o1, Service o2) {
+
+                        try {
+                            final String host1 = new ServiceUUID(o1.getUuid())
+                                    .getAddress().getHostName();
+                            final String host2 = new ServiceUUID(o2.getUuid())
+                                    .getAddress().getHostName();
+
+                            return getMatch(host2, clientIP.getHostName()) -
+                                    getMatch
+                                    (host1, clientIP.getHostName());
+
+                        } catch (UnknownUUIDException exc) {
+                            Logging.logError(Logging.LEVEL_ERROR, this, exc);
+                            return 0;
+                        }
+                    }
+                });
+
         // find the closest group to the client that is large enough
         String currentDomain = "";
         int currentDomainSize = 0;
         int currentIndex = 0;
-        
+
         int bestClientMatch = 0;
         int bestIndex = -1;
-        
+
         for (int i = 0; i < allOSDs.getServicesCount(); i++) {
-            
+
             try {
                 Service s = allOSDs.getServices(i);
-                String hostName = new ServiceUUID(s.getUuid()).getAddress().getHostName();
+                String hostName = new ServiceUUID(s.getUuid()).getAddress()
+                        .getHostName();
                 String domain = NetUtils.getDomain(hostName);
-                
+
                 if (domain.equals(currentDomain)) {
-                    
+
                     currentDomainSize++;
                     if (currentDomainSize == numOSDs) {
-                        int cd = getMatch(hostName, clientIP.getCanonicalHostName());
+                        int cd = getMatch(hostName, clientIP
+                                .getCanonicalHostName());
+                        if (cd > bestClientMatch) {
+                            bestClientMatch = cd;
+                            bestIndex = currentIndex;
+                        }
+                    }
+                } else {
+                    currentDomainSize = 1;
+                    currentDomain = domain;
+                    currentIndex = i;
+
+                    if (currentDomainSize == numOSDs) {
+                        int cd = getMatch(hostName, clientIP
+                                .getCanonicalHostName());
                         if (cd > bestClientMatch) {
                             bestClientMatch = cd;
                             bestIndex = currentIndex;
@@ -85,45 +111,31 @@ public class GroupFQDNPolicy extends FQDNPolicyBase {
                     }
                 }
 
-                else {
-                    currentDomainSize = 1;
-                    currentDomain = domain;
-                    currentIndex = i;
-                    
-                    if (currentDomainSize == numOSDs) {
-                        int cd = getMatch(hostName, clientIP.getCanonicalHostName());
-                        if (cd > bestClientMatch) {
-                            bestClientMatch = cd;
-                            bestIndex = currentIndex;
-                        }
-                    }
-                }
-                
             } catch (UnknownUUIDException exc) {
                 Logging.logError(Logging.LEVEL_ERROR, this, exc);
                 break;
             }
-            
+
         }
-        
+
         ServiceSet.Builder result = ServiceSet.newBuilder();
-        
+
         if (bestIndex != -1)
             for (int i = 0; i < numOSDs; i++)
                 result.addServices(allOSDs.getServices(bestIndex + i));
-        
+
         return result;
-        
+
     }
-    
+
     @Override
     public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs) {
         return allOSDs;
     }
-    
+
     @Override
     public void setAttribute(String key, String value) {
         // don't accept any attributes
     }
-    
+
 }

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/OSDSelectionPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/OSDSelectionPolicy.java
@@ -16,51 +16,53 @@ import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.VivaldiCoordinates;
 
 /**
  * Interface for policies implementing a selection mechanism for OSDs.
- * 
+ *
  * @author stender
  */
 public interface OSDSelectionPolicy {
-    
+
     /**
      * Selects a list of OSDs.
-     * 
-     * @param allOSDs
-     *            a list of all available OSDs
-     * @param clientIP
-     *            the client's IP address
-     * @param clientCoords
-     *            the client's Vivaldi coordinates
-     * @param currentXLoc
-     *            the current X-Locations list
-     * @param numOSDs
-     *            the number of OSDs required in a valid group. This is only relevant for grouping and will be ignored
-     *            by filtering and sorting policies.
+     *
+     * @param allOSDs      a list of all available OSDs
+     * @param clientIP     the client's IP address
+     * @param clientCoords the client's Vivaldi coordinates
+     * @param currentXLoc  the current X-Locations list
+     * @param numOSDs      the number of OSDs required in a valid group. This
+     *                     is only relevant for grouping and will be ignored
+     *                     by filtering and sorting policies.
+     * @param path         the path of the file.
+     *                     might be null if the path is
+     *                     currently unavailable.
      * @return a list of selected OSDs
      */
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress clientIP, VivaldiCoordinates clientCoords,
-        XLocList currentXLoc, int numOSDs);
-    
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path);
+
     /**
      * Simplified version of
-     * <code>getOSDs(ServiceSet allOSDs, InetAddress clientIP, XLocList currentXLoc, int numOSDs)</code>.
-     * This method will be invoked by the framework if no context is available e.g., when displaying
+     * <code>getOSDs(ServiceSet allOSDs, InetAddress clientIP, XLocList
+     * currentXLoc, int numOSDs)</code>.
+     * This method will be invoked by the framework if no context is
+     * available e.g., when displaying
      * the list of suitable OSDs in the webinterface or a maintenance tool.
-     * 
-     * @param allOSDs
-     *            a list of all available OSDs
+     *
+     * @param allOSDs a list of all available OSDs
      * @return a list of selected OSDs
      */
     public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs);
-    
+
     /**
      * Sets a new policy attribute. This method is invoked each time a
      * policy-related extended attribute is set.
-     * 
-     * @param key
-     *            the attribute key
-     * @param value
-     *            the attribute value
+     *
+     * @param key   the attribute key
+     * @param value the attribute value
      */
     public void setAttribute(String key, String value);
-    
+
 }

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/OSDStatusManager.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/OSDStatusManager.java
@@ -207,7 +207,7 @@ public class OSDStatusManager extends LifeCycleThread implements VolumeChangeLis
      * @return a list of feasible OSDs
      */
     public synchronized ServiceSet.Builder getUsableOSDs(String volumeId, InetAddress clientIP,
-        VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
+        VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs, String path) {
         
         VolumeOSDFilter vol = volumeMap.get(volumeId);
         if (vol == null) {
@@ -217,8 +217,12 @@ public class OSDStatusManager extends LifeCycleThread implements VolumeChangeLis
         }
         
         // return a set of OSDs
-        ServiceSet.Builder result = vol.filterByOSDSelectionPolicy(knownOSDs, clientIP, clientCoords,
-            currentXLoc, numOSDs);
+        ServiceSet.Builder result = vol.filterByOSDSelectionPolicy(knownOSDs,
+                                                                   clientIP,
+                                                                   clientCoords,
+                                                                   currentXLoc,
+                                                                   numOSDs,
+                                                                   path);
         
         return result;
     }
@@ -237,7 +241,7 @@ public class OSDStatusManager extends LifeCycleThread implements VolumeChangeLis
     }
     
     public synchronized Replicas getSortedReplicaList(String volumeId, InetAddress clientIP,
-        VivaldiCoordinates clientCoords, List<Replica> repls, XLocList xLocList) {
+        VivaldiCoordinates clientCoords, List<Replica> repls, XLocList xLocList, String path) {
         
         VolumeOSDFilter vol = volumeMap.get(volumeId);
         if (vol == null) {
@@ -247,7 +251,8 @@ public class OSDStatusManager extends LifeCycleThread implements VolumeChangeLis
         }
         
         // return a sorted set of replicas
-        return vol.sortByReplicaSelectionPolicy(clientIP, clientCoords, repls, xLocList);
+        return vol.sortByReplicaSelectionPolicy(clientIP, clientCoords,
+                                                repls, xLocList, path);
         
     }
     

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/PolicyHelper.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/PolicyHelper.java
@@ -9,12 +9,10 @@
 package org.xtreemfs.mrc.osdselection;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 
 import org.xtreemfs.mrc.metadata.XLoc;
@@ -67,20 +65,13 @@ public class PolicyHelper {
         return ServiceSet.newBuilder().addAllServices(list);
     }
     
-    public static ServiceSet.Builder shuffleServiceSet(ServiceSet.Builder set,
-                                                       Random random) {
+    public static ServiceSet.Builder shuffleServiceSet(ServiceSet.Builder set) {
+        
         List<Service> immutableList = set.getServicesList();
         List<Service> list = new ArrayList<Service>(immutableList);
-        if (random == null) {
-            Collections.shuffle(list);
-        } else {
-            Collections.shuffle(list, random);
-        }
+        Collections.shuffle(list);
+        
         return ServiceSet.newBuilder().addAllServices(list);
-    }
-
-    public static ServiceSet.Builder shuffleServiceSet(ServiceSet.Builder set) {
-        return shuffleServiceSet(set, null);
     }
 
     public static ServiceSet.Builder reverseServiceSet(ServiceSet.Builder set) {

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/PolicyHelper.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/PolicyHelper.java
@@ -9,10 +9,12 @@
 package org.xtreemfs.mrc.osdselection;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 
 import org.xtreemfs.mrc.metadata.XLoc;
@@ -65,13 +67,20 @@ public class PolicyHelper {
         return ServiceSet.newBuilder().addAllServices(list);
     }
     
-    public static ServiceSet.Builder shuffleServiceSet(ServiceSet.Builder set) {
-        
+    public static ServiceSet.Builder shuffleServiceSet(ServiceSet.Builder set,
+                                                       Random random) {
         List<Service> immutableList = set.getServicesList();
         List<Service> list = new ArrayList<Service>(immutableList);
-        Collections.shuffle(list);
-        
+        if (random == null) {
+            Collections.shuffle(list);
+        } else {
+            Collections.shuffle(list, random);
+        }
         return ServiceSet.newBuilder().addAllServices(list);
+    }
+
+    public static ServiceSet.Builder shuffleServiceSet(ServiceSet.Builder set) {
+        return shuffleServiceSet(set, null);
     }
 
     public static ServiceSet.Builder reverseServiceSet(ServiceSet.Builder set) {

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/PreferredUUIDPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/PreferredUUIDPolicy.java
@@ -42,7 +42,8 @@ public class PreferredUUIDPolicy implements OSDSelectionPolicy {
                                           GlobalTypes.VivaldiCoordinates
                                                   clientCoords,
                                           XLocList currentXLoc,
-                                          int numOSDs) {
+                                          int numOSDs,
+                                          String path) {
         return getOSDs(allOSDs);
     }
 

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortDCMapPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortDCMapPolicy.java
@@ -43,8 +43,12 @@ public class SortDCMapPolicy extends DCMapPolicyBase {
     }
     
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress clientIP,
-        VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
         
         final Inet4Address cAddr = (Inet4Address) clientIP;
         

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortFQDNPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortFQDNPolicy.java
@@ -19,54 +19,66 @@ import org.xtreemfs.foundation.util.OutputUtils;
 import org.xtreemfs.mrc.metadata.XLocList;
 import org.xtreemfs.pbrpc.generatedinterfaces.DIR.Service;
 import org.xtreemfs.pbrpc.generatedinterfaces.DIR.ServiceSet;
-import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.OSDSelectionPolicyType;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes
+        .OSDSelectionPolicyType;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.VivaldiCoordinates;
 
 /**
  * Sorts the list of OSDs in ascending order of their distance to the client.
  * The distance is determined by means of the server's and client's FQDNs.
- * 
+ *
  * @author bjko, stender
  */
 public class SortFQDNPolicy extends FQDNPolicyBase {
-    
-    public static final short POLICY_ID = (short) OSDSelectionPolicyType.OSD_SELECTION_POLICY_SORT_FQDN
-                                                .getNumber();
-    
+
+    public static final short POLICY_ID = (short) OSDSelectionPolicyType
+            .OSD_SELECTION_POLICY_SORT_FQDN
+            .getNumber();
+
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, final InetAddress clientIP,
-        VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
-        
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      final InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
+
         if (allOSDs == null)
             return null;
-        
-        allOSDs = PolicyHelper.sortServiceSet(allOSDs, new Comparator<Service>() {
+
+        allOSDs = PolicyHelper.sortServiceSet(allOSDs, new
+                Comparator<Service>() {
             public int compare(Service o1, Service o2) {
                 try {
-                    return getMatch(new ServiceUUID(o2.getUuid()).getAddress().getHostName(), clientIP
+                    return getMatch(new ServiceUUID(o2.getUuid()).getAddress
+                            ().getHostName(), clientIP
                             .getCanonicalHostName())
-                        - getMatch(new ServiceUUID(o1.getUuid()).getAddress().getHostName(), clientIP
-                                .getCanonicalHostName());
+                            - getMatch(new ServiceUUID(o1.getUuid())
+                                               .getAddress().getHostName(),
+                                       clientIP
+                            .getCanonicalHostName());
                 } catch (UnknownUUIDException e) {
-                    Logging.logMessage(Logging.LEVEL_WARN, Category.misc, this, "cannot compare FQDNs");
-                    Logging.logMessage(Logging.LEVEL_WARN, this, OutputUtils.stackTraceToString(e));
+                    Logging.logMessage(Logging.LEVEL_WARN, Category.misc,
+                                       this, "cannot compare FQDNs");
+                    Logging.logMessage(Logging.LEVEL_WARN, this, OutputUtils
+                            .stackTraceToString(e));
                     return 0;
                 }
             }
         });
-        
+
         return allOSDs;
-        
+
     }
-    
+
     @Override
     public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs) {
         return allOSDs;
     }
-    
+
     @Override
     public void setAttribute(String key, String value) {
         // don't accept any attributes
     }
-    
+
 }

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortHostRoundRobinPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortHostRoundRobinPolicy.java
@@ -19,8 +19,12 @@ public class SortHostRoundRobinPolicy implements OSDSelectionPolicy {
     public static final short POLICY_ID = (short) OSDSelectionPolicyType.OSD_SELECTION_POLICY_SORT_HOST_ROUND_ROBIN
                                                 .getNumber();
     @Override
-    public Builder getOSDs(Builder allOSDs, InetAddress clientIP, VivaldiCoordinates clientCoords,
-            XLocList currentXLoc, int numOSDs) {
+    public Builder getOSDs(Builder allOSDs,
+                           InetAddress clientIP,
+                           VivaldiCoordinates clientCoords,
+                           XLocList currentXLoc,
+                           int numOSDs,
+                           String path) {
         return getOSDs(allOSDs);
     }
 

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortRandomPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortRandomPolicy.java
@@ -39,10 +39,12 @@ public class SortRandomPolicy implements OSDSelectionPolicy {
     private Random random = null;
 
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress
-            clientIP,
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      InetAddress clientIP,
                                       VivaldiCoordinates clientCoords,
-                                      XLocList currentXLoc, int numOSDs) {
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
         return getOSDs(allOSDs);
     }
 

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortRandomPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortRandomPolicy.java
@@ -9,35 +9,22 @@
 package org.xtreemfs.mrc.osdselection;
 
 import java.net.InetAddress;
-import java.util.Random;
 
 import org.xtreemfs.mrc.metadata.XLocList;
 import org.xtreemfs.pbrpc.generatedinterfaces.DIR.ServiceSet;
-import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes
-        .OSDSelectionPolicyType;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.OSDSelectionPolicyType;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.VivaldiCoordinates;
 
 /**
  * Randomly shuffles the list of OSDs.
- *
+ * 
  * @author stender
  */
 public class SortRandomPolicy implements OSDSelectionPolicy {
-
-    public static final short POLICY_ID = (short) OSDSelectionPolicyType
-            .OSD_SELECTION_POLICY_SORT_RANDOM
-            .getNumber();
-
-    /*
-    identifier for setting the preferred UUID attribute
-    */
-    private static final String attributeKeyString = "randomseed";
-
-    /*
-    the source of randomness
-     */
-    private Random random = null;
-
+    
+    public static final short POLICY_ID = (short) OSDSelectionPolicyType.OSD_SELECTION_POLICY_SORT_RANDOM
+                                                .getNumber();
+    
     @Override
     public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
                                       InetAddress clientIP,
@@ -45,31 +32,23 @@ public class SortRandomPolicy implements OSDSelectionPolicy {
                                       XLocList currentXLoc,
                                       int numOSDs,
                                       String path) {
+
         return getOSDs(allOSDs);
     }
-
+    
     @Override
     public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs) {
-
+        
         if (allOSDs == null)
             return null;
-
-        allOSDs = PolicyHelper.shuffleServiceSet(allOSDs, this.random);
+        
+        allOSDs = PolicyHelper.shuffleServiceSet(allOSDs);
         return allOSDs;
     }
-
+    
     @Override
     public void setAttribute(String key, String value) {
-        // take care: using a specific random seed does not imply deterministic
-        // osd selection, only approximately.
-        if (key.equals(attributeKeyString)) {
-            try {
-                long seed = Long.parseLong(value);
-                this.random = new Random(seed);
-            } catch (NumberFormatException e) {
-                this.random = null;
-            }
-        }
+        // don't accept any attributes
     }
-
+    
 }

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortReversePolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortReversePolicy.java
@@ -22,8 +22,12 @@ public class SortReversePolicy implements OSDSelectionPolicy {
     public static final short POLICY_ID = (short) OSDSelectionPolicyType.OSD_SELECTION_POLICY_SORT_REVERSE.getNumber();
 
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress clientIP,
-        VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
         return getOSDs(allOSDs);
     }
 

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortUUIDPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortUUIDPolicy.java
@@ -24,8 +24,12 @@ public class SortUUIDPolicy implements OSDSelectionPolicy {
     public static final short POLICY_ID = (short) OSDSelectionPolicyType.OSD_SELECTION_POLICY_SORT_UUID.getNumber();
 
     @Override
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, final InetAddress clientIP,
-            VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      final InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
 
         if (allOSDs == null) {
             return null;

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortVivaldiPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/SortVivaldiPolicy.java
@@ -30,8 +30,12 @@ public class SortVivaldiPolicy implements OSDSelectionPolicy {
     public static final short POLICY_ID = (short) OSDSelectionPolicyType.OSD_SELECTION_POLICY_SORT_VIVALDI
                                                 .getNumber();
     
-    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs, InetAddress clientIP,
-        VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
+    public ServiceSet.Builder getOSDs(ServiceSet.Builder allOSDs,
+                                      InetAddress clientIP,
+                                      VivaldiCoordinates clientCoords,
+                                      XLocList currentXLoc,
+                                      int numOSDs,
+                                      String path) {
         
         if (allOSDs == null)
             return null;

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/VolumeOSDFilter.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/VolumeOSDFilter.java
@@ -152,7 +152,7 @@ public class VolumeOSDFilter {
     }
 
     public ServiceSet.Builder filterByOSDSelectionPolicy(ServiceSet.Builder knownOSDs, InetAddress clientIP,
-            VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs) {
+            VivaldiCoordinates clientCoords, XLocList currentXLoc, int numOSDs, String path) {
 
         ServiceSet.Builder result = ServiceSet.newBuilder().addAllServices(knownOSDs.getServicesList());
         for (short id : osdPolicy) {
@@ -163,7 +163,8 @@ public class VolumeOSDFilter {
                 continue;
             }
 
-            result = policy.getOSDs(result, clientIP, clientCoords, currentXLoc, numOSDs);
+            result = policy.getOSDs(result, clientIP, clientCoords,
+                                    currentXLoc, numOSDs, path);
         }
 
         return result;
@@ -189,7 +190,7 @@ public class VolumeOSDFilter {
     }
 
     public Replicas sortByReplicaSelectionPolicy(InetAddress clientIP, VivaldiCoordinates clientCoords,
-            List<Replica> unsortedRepls, XLocList xLocList) {
+            List<Replica> unsortedRepls, XLocList xLocList, String path) {
 
         // head OSD -> replica
         Map<String, Replica> replMap = new HashMap<String, Replica>();
@@ -230,7 +231,7 @@ public class VolumeOSDFilter {
             }
 
             headOSDServiceSetBuilder = policy.getOSDs(headOSDServiceSetBuilder, clientIP, clientCoords,
-                    xLocList, headOSDServiceSetBuilder.getServicesCount());
+                    xLocList, headOSDServiceSetBuilder.getServicesCount(), path);
         }
 
         // arrange the resulting list of replicas in the same order as the list

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/utils/MRCHelper.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/utils/MRCHelper.java
@@ -244,7 +244,7 @@ public class MRCHelper {
 
         // determine the set of OSDs to be assigned to the replica
         ServiceSet.Builder usableOSDs = osdMan.getUsableOSDs(volume.getId(), clientAddress, clientCoordinates,
-                currentXLoc, stripingPolicy.getWidth());
+                currentXLoc, stripingPolicy.getWidth(), path);
 
         if (usableOSDs == null || usableOSDs.getServicesCount() == 0) {
 

--- a/java/xtreemfs-servers/src/test/java/org/xtreemfs/test/mrc/OSDPolicyTest.java
+++ b/java/xtreemfs-servers/src/test/java/org/xtreemfs/test/mrc/OSDPolicyTest.java
@@ -339,14 +339,14 @@ public class OSDPolicyTest {
         
         InetAddress clientAddr = InetAddress.getByName("192.168.2.100");
         ServiceSet.Builder sortedList = policy.getOSDs(osds.toBuilder(), clientAddr, null, null,
-            Integer.MAX_VALUE);
+            Integer.MAX_VALUE, null);
         assertEquals("osd1", sortedList.getServices(0).getUuid());
         assertEquals("osd4", sortedList.getServices(1).getUuid());
         assertEquals("osd2", sortedList.getServices(2).getUuid());
         assertEquals("osd3", sortedList.getServices(3).getUuid());
         
         clientAddr = InetAddress.getByName("192.168.3.100");
-        sortedList = policy.getOSDs(osds.toBuilder(), clientAddr, null, null, Integer.MAX_VALUE);
+        sortedList = policy.getOSDs(osds.toBuilder(), clientAddr, null, null, Integer.MAX_VALUE, null);
         assertEquals("osd2", sortedList.getServices(0).getUuid());
         assertEquals("osd1", sortedList.getServices(1).getUuid());
         assertEquals("osd4", sortedList.getServices(2).getUuid());
@@ -385,7 +385,7 @@ public class OSDPolicyTest {
         // get two OSDs from one data center
         InetAddress clientAddr = InetAddress.getByName("192.168.2.100");
         ServiceSet.Builder sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(
-            osds.getServicesList()), clientAddr, null, null, 2);
+            osds.getServicesList()), clientAddr, null, null, 2, null);
         assertEquals(2, sortedList.getServicesCount());
         assertEquals("osd1", sortedList.getServices(0).getUuid());
         assertEquals("osd4", sortedList.getServices(1).getUuid());
@@ -393,12 +393,12 @@ public class OSDPolicyTest {
         // request too many OSDs
         clientAddr = InetAddress.getByName("192.168.2.100");
         sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(osds.getServicesList()),
-            clientAddr, null, null, 3);
+            clientAddr, null, null, 3, null);
         assertEquals(0, sortedList.getServicesCount());
         
         clientAddr = InetAddress.getByName("192.168.3.100");
         sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(osds.getServicesList()),
-            clientAddr, null, null, 1);
+            clientAddr, null, null, 1, null);
         assertEquals(1, sortedList.getServicesCount());
         assertEquals("osd2", sortedList.getServices(0).getUuid());
         
@@ -429,7 +429,7 @@ public class OSDPolicyTest {
         
         InetAddress clientAddr = InetAddress.getByName("xtreem.zib.de");
         ServiceSet.Builder sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(
-            osds.getServicesList()), clientAddr, null, null, Integer.MAX_VALUE);
+            osds.getServicesList()), clientAddr, null, null, Integer.MAX_VALUE, null);
         assertEquals("osd1", sortedList.getServices(0).getUuid());
         assertEquals("osd3", sortedList.getServices(1).getUuid());
         assertEquals("osd4", sortedList.getServices(2).getUuid());
@@ -438,7 +438,7 @@ public class OSDPolicyTest {
         
         clientAddr = InetAddress.getByName("www.berlin.de");
         sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(osds.getServicesList()),
-            clientAddr, null, null, Integer.MAX_VALUE);
+            clientAddr, null, null, Integer.MAX_VALUE, null);
         
         assertEquals("osd2", sortedList.getServices(0).getUuid());
     }
@@ -468,23 +468,23 @@ public class OSDPolicyTest {
         
         InetAddress clientAddr = InetAddress.getByName("xtreem.zib.de");
         ServiceSet.Builder sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(
-            osds.getServicesList()), clientAddr, null, null, 1);
+            osds.getServicesList()), clientAddr, null, null, 1, null);
         assertEquals(1, sortedList.getServicesCount());
         assertEquals("osd1", sortedList.getServices(0).getUuid());
         
         sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(osds.getServicesList()),
-            clientAddr, null, null, 2);
+            clientAddr, null, null, 2, null);
         assertEquals(2, sortedList.getServicesCount());
         assertEquals("osd1", sortedList.getServices(0).getUuid());
         assertEquals("osd3", sortedList.getServices(1).getUuid());
         
         sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(osds.getServicesList()),
-            clientAddr, null, null, 4);
+            clientAddr, null, null, 4, null);
         assertEquals(0, sortedList.getServicesCount());
         
         clientAddr = InetAddress.getByName("www.berlin.de");
         sortedList = policy.getOSDs(ServiceSet.newBuilder().addAllServices(osds.getServicesList()),
-            clientAddr, null, null, 1);
+            clientAddr, null, null, 1, null);
         assertEquals(1, sortedList.getServicesCount());
         assertEquals("osd2", sortedList.getServices(0).getUuid());
         
@@ -553,7 +553,7 @@ public class OSDPolicyTest {
         VivaldiCoordinates clientCoordinates = VivaldiCoordinates.newBuilder().setXCoordinate(0.0)
                 .setYCoordinate(0.0).setLocalError(0.1).build();
         
-        ServiceSet.Builder sortedList = policy.getOSDs(osds, clientAddr, clientCoordinates, null, 0);
+        ServiceSet.Builder sortedList = policy.getOSDs(osds, clientAddr, clientCoordinates, null, 0, null);
         
         assertEquals("osd3", sortedList.getServices(0).getUuid());
         assertEquals("osd2", sortedList.getServices(1).getUuid());


### PR DESCRIPTION
Extended OSDSelectionPolicy interface such that getOSDs now receives the file path as parameter. 
Added an OSDSelectionPolicy that selects OSDs based on file path prefixes.

commit 57e354e is reverted by commit 097a298 (which does nothing but reverting 57e354e), hence only commits 78aa1ba and f2cc801 carry actual change.