### PR TITLE
STANDARD_ACCESS_WRITE does not necessarily indicate desired write access

### DIFF
--- a/cpp/src/cbfs/cbfs_adapter.cpp
+++ b/cpp/src/cbfs/cbfs_adapter.cpp
@@ -1282,7 +1282,11 @@ xtreemfs::pbrpc::SYSTEM_V_FCNTL CbFSAdapter::ConvertFlagsWindowsToXtreemFS(
   write |= (desired_access & FILE_WRITE_ATTRIBUTES) != 0;
   write |= (desired_access & FILE_WRITE_DATA) != 0;
   write |= (desired_access & FILE_WRITE_EA) != 0;
-  write |= (desired_access & STANDARD_RIGHTS_WRITE) != 0;
+
+  // STANDARD_RIGHTS_WRITE is equal to STANDARD_RIGHTS_READ, therefore not
+  // distinguishable from read-only access. The application will need to request
+  // specific desired access for write permissions.
+  // write |= (desired_access & STANDARD_RIGHTS_WRITE) != 0;
   
   int open_flags = 0;
   if (read && write) {


### PR DESCRIPTION
See comment in the code. In effect the client would always request RW access, even if read-only would have been sufficient. This would, for example, prevent an -r-xr-xr-x file (on the server) from being copied onto a machine using the Windows client.