### PR TITLE
changed default behaviour of OSDSelectionPolicies

### DIFF
--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/PreferredUUIDPolicy.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/osdselection/PreferredUUIDPolicy.java
@@ -68,7 +68,8 @@ public class PreferredUUIDPolicy implements OSDSelectionPolicy {
         if (preferredService != null) {
             OSDsInCorrectOrder.add(0, preferredService);
         }
-
+        
+        Collections.shuffle(nonPreferredServices);
         OSDsInCorrectOrder.addAll(nonPreferredServices);
 
         return DIR.ServiceSet.newBuilder().addAllServices(OSDsInCorrectOrder);

--- a/java/xtreemfs-servers/src/test/java/org/xtreemfs/test/mrc/OSDPolicyTest.java
+++ b/java/xtreemfs-servers/src/test/java/org/xtreemfs/test/mrc/OSDPolicyTest.java
@@ -632,7 +632,6 @@ public class OSDPolicyTest {
                                                      0,
                                                      "volume/dir1/file");
 
-        assertEquals(1, selectedOSD.getServicesCount());
         assertEquals("osd2", selectedOSD.getServices(0).getUuid());
 
         pol.setAttribute("filenamePrefix", "remove /volume/dir1 osd2");
@@ -654,7 +653,6 @@ public class OSDPolicyTest {
                                   0,
                                   "volume/dir1/dirx/file");
 
-        assertEquals(1, selectedOSD.getServicesCount());
         assertEquals("osd1", selectedOSD.getServices(0).getUuid());
 
         pol.setAttribute("filenamePrefix", "clear");
@@ -670,6 +668,17 @@ public class OSDPolicyTest {
         // no value is expected to be set
         assertEquals(3, selectedOSD.getServicesCount());
 
+        pol.setAttribute("filenamePrefix", "clear");
+        pol.setAttribute("filenamePrefix", "add /volume/dir1 osdX");
+
+        selectedOSD = pol.getOSDs(services.toBuilder(),
+                                  null,
+                                  null,
+                                  null,
+                                  0,
+                                  "volume/dir1/file");
+
+        assertEquals(3, selectedOSD.getServicesCount());
     }
 
     private static ServiceDataMap getDefaultServiceDataMap() {


### PR DESCRIPTION
The default behaviour of the OSDSelectionPolicies PreferredUUIDPolicy and FileNamePrefixPolicy is changed such that:
- when an OSD corresponding to the configuration of the policy is found, it is the first element in the list of returned OSDs; all other OSDs are appended to this list in random order.
- when no OSD corresponding to the configuration of the policy is found, all available OSDs are returned in random order.

This is more similar to the normal behaviour (when no OSDSelectionPolicy is explicitly chosen, the SortRandomPolicy is used). 
It prevents that a whole XtreemFS setup is dependant on a single OSD.