### PR TITLE
towards a fix of issue 223

### DIFF
--- a/interface/xtreemfs/MRC.proto
+++ b/interface/xtreemfs/MRC.proto
@@ -534,6 +534,14 @@ message xtreemfs_replica_addResponse {
   required int32 expected_xlocset_version = 2;
 }
 
+// requests that a replica is marked as complete replica
+message xtreemfs_replica_mark_completeRequest {
+  // the file ID
+  optional string file_id = 1;
+  // the osd UUID
+  optional string osd_uuid = 2;
+}
+
 // requests a list of all replicas of a file (deprecated)
 message xtreemfs_replica_listRequest {
   // the file ID
@@ -816,6 +824,11 @@ service MRCService {
   // requests the addition of a replica to a file
   rpc xtreemfs_replica_add(xtreemfs_replica_addRequest) returns(xtreemfs_replica_addResponse) {
     option(proc_id)=39;
+  };
+
+  // marks a replica as complete (e.g., the osd has fetched all objects of the file)
+  rpc xtreemfs_replica_mark_complete(xtreemfs_replica_mark_completeRequest) returns(emptyResponse) {
+    option(proc_id)=49;
   };
 
   // lists all replicas of a file (deprecated)

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/AddReplicaOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/AddReplicaOperation.java
@@ -201,6 +201,14 @@ public class AddReplicaOperation extends MRCOperation implements XLocSetCoordina
     @Override
     public void installXLocSet(String fileId, XLocList xLocList, XLocList oldxLocList) throws Throwable {
 
+        if (Logging.isDebug()) {
+            Logging.logMessage(Logging.LEVEL_DEBUG, Logging.Category.replication,
+                               this,
+                               "installing xlocset for file %s." +
+                                       "new xlocset: %s",
+                               fileId, xLocList.toString());
+        }
+
         final VolumeManager vMan = master.getVolumeManager();
         final GlobalFileIdResolver idRes = new GlobalFileIdResolver(fileId);
         final StorageManager sMan = vMan.getStorageManager(idRes.getVolumeId());
@@ -228,6 +236,15 @@ public class AddReplicaOperation extends MRCOperation implements XLocSetCoordina
         final VolumeManager vMan = master.getVolumeManager();
         final GlobalFileIdResolver idRes = new GlobalFileIdResolver(fileId);
         final StorageManager sMan = vMan.getStorageManager(idRes.getVolumeId());
+
+        if (Logging.isDebug()) {
+            Logging.logMessage(Logging.LEVEL_DEBUG,
+                               Logging.Category.replication,
+                               this,
+                               "installing xlocset of file: %s" +
+                                       " handling error. New xlocset: %s",
+                               fileId, newXLocList.toString());
+        }
 
         // Retrieve the file metadata.
         final FileMetadata file = sMan.getMetadata(idRes.getLocalFileId());

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/MarkReplicaCompleteOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/MarkReplicaCompleteOperation.java
@@ -1,0 +1,228 @@
+package org.xtreemfs.mrc.operations;
+
+import org.xtreemfs.common.xloc.ReplicationFlags;
+import org.xtreemfs.foundation.logging.Logging;
+import org.xtreemfs.foundation.pbrpc.generatedinterfaces.RPC;
+import org.xtreemfs.mrc.MRCRequest;
+import org.xtreemfs.mrc.MRCRequestDispatcher;
+import org.xtreemfs.mrc.UserException;
+import org.xtreemfs.mrc.database.AtomicDBUpdate;
+import org.xtreemfs.mrc.database.StorageManager;
+import org.xtreemfs.mrc.database.VolumeManager;
+import org.xtreemfs.mrc.metadata.FileMetadata;
+import org.xtreemfs.mrc.metadata.XLoc;
+import org.xtreemfs.mrc.metadata.XLocList;
+import org.xtreemfs.mrc.stages.XLocSetCoordinator;
+import org.xtreemfs.mrc.stages.XLocSetCoordinatorCallback;
+import org.xtreemfs.mrc.utils.MRCHelper;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC
+        .xtreemfs_replica_mark_completeRequest;
+
+import org.xtreemfs.pbrpc.generatedinterfaces.Common.emptyResponse;
+
+/**
+ * MRC operation to mark a previously added replica as a complete replica.
+ * This operation should only be used by an OSD when it fetched and stored all
+ * objects locally (e.g. when the replication completed successfully).
+ * <p>
+ * This operation is only necessary for read-only replication.
+ * Probably we should throw some exception if the file's replication policy is
+ * not read-only.
+ *
+ * TODO support stripe width > 1 (e.g., single replica on more than one OSD).
+ */
+public class MarkReplicaCompleteOperation extends MRCOperation implements
+        XLocSetCoordinatorCallback {
+
+    public MarkReplicaCompleteOperation(MRCRequestDispatcher master) {
+        super(master);
+    }
+
+    @Override
+    public void startRequest(MRCRequest rq) throws Throwable {
+        final xtreemfs_replica_mark_completeRequest rqArgs =
+                (xtreemfs_replica_mark_completeRequest) rq.getRequestArgs();
+
+        String fileID = rqArgs.getFileId();
+        String osdWithCompleteReplica = rqArgs.getOsdUuid();
+
+        MRCHelper.GlobalFileIdResolver idResolver = new MRCHelper
+                .GlobalFileIdResolver(fileID);
+
+        VolumeManager volumeManager = master.getVolumeManager();
+
+        StorageManager storageManager =
+                volumeManager.getStorageManager(idResolver.getVolumeId());
+
+        org.xtreemfs.mrc.metadata.FileMetadata fileMetadata =
+                storageManager.getMetadata(idResolver.getLocalFileId());
+
+        XLocList xLocList = fileMetadata.getXLocList();
+
+        if (Logging.isDebug()) {
+            logXLocInfo(xLocList);
+        }
+
+        // assume that there is exactly one entry in the xLocList for
+        // OSD osdWithCompleteReplica
+        XLoc replicaToBeUpdated = null;
+        for (int i = 0; i < xLocList.getReplicaCount(); i++) {
+            if (osdWithCompleteReplica
+                    .equals(xLocList.getReplica(i).getOSD(0))) {
+                replicaToBeUpdated = xLocList.getReplica(i);
+                break;
+            }
+        }
+        if (replicaToBeUpdated == null) {
+            // the file has probably been deleted in the meantime.
+            Logging.logMessage(Logging.LEVEL_WARN, Logging.Category.replication, this,
+                               "OSD %s not found in XLocs of file %s",
+                               osdWithCompleteReplica, fileID);
+            return;
+        }
+
+        int updatedReplicationFlag =
+                ReplicationFlags.setReplicaIsComplete(
+                        replicaToBeUpdated.getReplicationFlags());
+        replicaToBeUpdated.setReplicationFlags(updatedReplicationFlag);
+        XLoc updatedReplica = replicaToBeUpdated;
+
+        XLoc[] updatedXLocs = new XLoc[xLocList.getReplicaCount()];
+        for (int i = 0; i < xLocList.getReplicaCount(); i++) {
+            if (osdWithCompleteReplica
+                    .equals(xLocList.getReplica(i).getOSD(0))) {
+                // if the read-only replica has more than one OSD location,
+                // setting the complete flag will likely be erroneous
+                // (as all OSDs have to fetch all their objects of the file,
+                // in order for the replica to be complete)
+                updatedXLocs[i] = updatedReplica;
+            } else {
+                updatedXLocs[i] = xLocList.getReplica(i);
+            }
+        }
+
+        if (Logging.isDebug()) {
+            StringBuilder updateSB = new StringBuilder();
+            updateSB.append("updated XLocs: ");
+            for (int i = 0; i < updatedXLocs.length; i++) {
+                updateSB
+                        .append("replica: ")
+                        .append(i)
+                        .append(" replication flags: ")
+                        .append(updatedXLocs[i].getReplicationFlags())
+                        .append(" osdUUID: ")
+                        .append(updatedXLocs[i].getOSD(0))
+                        .append(" ");
+            }
+            Logging.logMessage(Logging.LEVEL_DEBUG,
+                               Logging.Category.replication,
+                               this,
+                               updateSB.toString());
+        }
+
+        XLocList updatedXLocList =
+                storageManager.createXLocList(updatedXLocs,
+                                              xLocList.getReplUpdatePolicy(),
+                                              xLocList.getVersion() + 1);
+
+        XLocSetCoordinator xLocSetCoordinator = master.getXLocSetCoordinator();
+        XLocSetCoordinator.RequestMethod requestMethod =
+                xLocSetCoordinator.requestXLocSetChange(fileID,
+                                                        fileMetadata,
+                                                        xLocList,
+                                                        updatedXLocList,
+                                                        rq, this);
+
+        AtomicDBUpdate atomicDBUpdate =
+                storageManager.createAtomicDBUpdate(xLocSetCoordinator,
+                                                    requestMethod);
+
+        xLocSetCoordinator.lockXLocSet(fileMetadata,
+                                       storageManager,
+                                       atomicDBUpdate);
+
+        atomicDBUpdate.execute();
+
+        if (Logging.isDebug()) {
+            Logging.logMessage(Logging.LEVEL_DEBUG, this,
+                               "Replica on OSD %s of file with id %s is now " +
+                                       "marked as complete",
+                               osdWithCompleteReplica, fileID);
+        }
+
+        rq.setResponse(emptyResponse.getDefaultInstance());
+    }
+
+    @Override
+    public void installXLocSet(String fileId, XLocList newXLocList, XLocList
+            prevXLocList) throws Throwable {
+        VolumeManager volumeManager = master.getVolumeManager();
+        MRCHelper.GlobalFileIdResolver idResolver = new MRCHelper
+                .GlobalFileIdResolver(fileId);
+        StorageManager storageManager =
+                volumeManager.getStorageManager(idResolver.getVolumeId());
+
+        // Retrieve the file metadata.
+        final FileMetadata fileMetadata =
+                storageManager.getMetadata(idResolver.getLocalFileId());
+        if (fileMetadata == null) {
+            // if the file does not exist, it has probably deleted in the
+            // meantime, which should be fine
+            Logging.logMessage(Logging.LEVEL_DEBUG,
+                               Logging.Category.replication,
+                               this,
+                               "marking replica as complete failed" +
+                                       "because file %s does not exist " +
+                                       "(anymore)", fileId);
+            return;
+        }
+
+        AtomicDBUpdate update = storageManager.createAtomicDBUpdate(null,
+                                                                    null);
+
+        // Update the X-Locations list.
+        fileMetadata.setXLocList(newXLocList);
+        storageManager.setMetadata(fileMetadata, FileMetadata.RC_METADATA,
+                                   update);
+
+        master.getXLocSetCoordinator().unlockXLocSet(fileMetadata,
+                                                     storageManager,
+                                                     update);
+        update.execute();
+    }
+
+    @Override
+    public void handleInstallXLocSetError(Throwable error, String fileId,
+                                          XLocList newXLocList, XLocList
+                                                  prevXLocList) throws
+            Throwable {
+        // not really clear under which conditions this method is called
+        Logging.logMessage(Logging.LEVEL_WARN,
+                           Logging.Category.replication,
+                           this,
+                           "marking replica for file %s" +
+                                   " as complete failed" +
+                                   "because XLocSet change failed. Error: %s",
+                           fileId,
+                           error.toString());
+    }
+
+    private void logXLocInfo(XLocList xLocList) {
+        StringBuilder replicaInfo = new StringBuilder();
+        for (int i = 0; i < xLocList.getReplicaCount(); i++) {
+            replicaInfo
+                    .append("replica ")
+                    .append(i)
+                    .append(" osd: ")
+                    .append(xLocList.getReplica(i)
+                                    .getOSD(0))
+                    .append(" replication flags: ")
+                    .append(xLocList.getReplica(i)
+                                    .getReplicationFlags())
+                    .append("\n");
+        }
+        Logging.logMessage(Logging.LEVEL_DEBUG, this,
+                           replicaInfo.toString());
+    }
+
+}

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/MarkReplicaCompleteOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/MarkReplicaCompleteOperation.java
@@ -141,6 +141,8 @@ public class MarkReplicaCompleteOperation extends MRCOperation implements
                                        storageManager,
                                        atomicDBUpdate);
 
+        rq.setResponse(emptyResponse.getDefaultInstance());
+
         atomicDBUpdate.execute();
 
         if (Logging.isDebug()) {
@@ -149,8 +151,6 @@ public class MarkReplicaCompleteOperation extends MRCOperation implements
                                        "marked as complete",
                                osdWithCompleteReplica, fileID);
         }
-
-        rq.setResponse(emptyResponse.getDefaultInstance());
     }
 
     @Override

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/RemoveReplicaOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/RemoveReplicaOperation.java
@@ -181,21 +181,39 @@ public class RemoveReplicaOperation extends MRCOperation implements XLocSetCoord
 
         // If the file is read-only replicated, check if at
         // least one complete or one full replica remains.
+
+        // (felse): a 'full' ronly replica does not necessarily contain all objects
+        // of a file. the check isFullReplica hence does not guarantee that
+        // all objects belonging to the deleted file are present after
+        // the requested replica deletion has been executed.
         if (ReplicaUpdatePolicies.isRO(oldXLocList.getReplUpdatePolicy())) {
 
-            boolean completeOrFullExists = false;
+//            boolean completeOrFullExists = false;
+//            for (int k = 0; k < newXLocList.getReplicaCount(); k++) {
+//                if (ReplicationFlags.isReplicaComplete(newXLocList.getReplica(k).getReplicationFlags())
+//                        || ReplicationFlags.isFullReplica(newXLocList.getReplica(k).getReplicationFlags())) {
+//                    completeOrFullExists = true;
+//                    break;
+//                }
+//            }
+
+            boolean completeExists = false;
             for (int k = 0; k < newXLocList.getReplicaCount(); k++) {
-                if (ReplicationFlags.isReplicaComplete(newXLocList.getReplica(k).getReplicationFlags())
-                        || ReplicationFlags.isFullReplica(newXLocList.getReplica(k).getReplicationFlags())) {
-                    completeOrFullExists = true;
-                    break;
+                if (ReplicationFlags.isReplicaComplete(newXLocList.getReplica(k).getReplicationFlags())) {
+                    completeExists = true;
                 }
             }
 
-            if (!completeOrFullExists) {
+//            if (!completeOrFullExists) {
+//                throw new UserException(POSIXErrno.POSIX_ERROR_EINVAL, "Could not remove OSD '" + rqArgs.getOsdUuid()
+//                        + "': read-only replication w/ partial replicas requires at "
+//                        + "least one remaining replica that is full or complete");
+//            }
+
+            if (!completeExists) {
                 throw new UserException(POSIXErrno.POSIX_ERROR_EINVAL, "Could not remove OSD '" + rqArgs.getOsdUuid()
-                        + "': read-only replication w/ partial replicas requires at "
-                        + "least one remaining replica that is full or complete");
+                        + "': read-only replication requires at "
+                        + "least one remaining replica that is complete");
             }
         }
 

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/SetReplicaUpdatePolicyOperation.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/operations/SetReplicaUpdatePolicyOperation.java
@@ -154,7 +154,7 @@ public class SetReplicaUpdatePolicyOperation extends MRCOperation {
             // if there is more than one replica, report an error
             if (curXLocList.getReplicaCount() > 1)
                 throw new UserException(POSIXErrno.POSIX_ERROR_EINVAL,
-                        "number of replicas has to be reduced 1 before replica update policy can be set to "
+                        "number of replicas has to be reduced to 1 before replica update policy can be set to "
                                 + ReplicaUpdatePolicies.REPL_UPDATE_PC_NONE + " (current replica count = "
                                 + curXLocList.getReplicaCount() + ")");
         }

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/stages/ProcessingStage.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/stages/ProcessingStage.java
@@ -52,6 +52,7 @@ import org.xtreemfs.mrc.operations.GetXLocListOperation;
 import org.xtreemfs.mrc.operations.GetXLocSetOperation;
 import org.xtreemfs.mrc.operations.InternalDebugOperation;
 import org.xtreemfs.mrc.operations.MRCOperation;
+import org.xtreemfs.mrc.operations.MarkReplicaCompleteOperation;
 import org.xtreemfs.mrc.operations.MoveOperation;
 import org.xtreemfs.mrc.operations.OpenOperation;
 import org.xtreemfs.mrc.operations.ReadDirAndStatOperation;
@@ -128,6 +129,7 @@ public class ProcessingStage extends MRCStage {
         operations.put(MRCServiceConstants.PROC_ID_XTREEMFS_RENEW_CAPABILITY_AND_VOUCHER,
                 new RenewCapabilityAndVoucherOperation(master));
         operations.put(MRCServiceConstants.PROC_ID_XTREEMFS_REPLICA_ADD, new AddReplicaOperation(master));
+        operations.put(MRCServiceConstants.PROC_ID_XTREEMFS_REPLICA_MARK_COMPLETE, new MarkReplicaCompleteOperation(master));
         operations.put(MRCServiceConstants.PROC_ID_XTREEMFS_REPLICA_REMOVE,
             new RemoveReplicaOperation(master));
         operations.put(MRCServiceConstants.PROC_ID_XTREEMFS_REPLICA_LIST, new GetXLocListOperation(master));

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/utils/MRCHelper.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/mrc/utils/MRCHelper.java
@@ -651,6 +651,14 @@ public class MRCHelper {
             FileMetadata file, String keyString, String value, AtomicDBUpdate update)
                     throws UserException, DatabaseException {
 
+        if (Logging.isDebug()) {
+            Logging.logMessage(Logging.LEVEL_DEBUG, null,
+                               "calling setSysAttrValue in MRCHelper with arguments:" +
+                                       "master: %s sMan: %s parentId: %s " +
+                                       "file: %s keyString: %s value: %s update: %s",
+                               master, sMan, parentId, file, keyString, value, update);
+        }
+
         final VolumeManager vMan = master.getVolumeManager();
         final FileAccessManager faMan = master.getFileAccessManager();
 
@@ -675,6 +683,12 @@ public class MRCHelper {
             key = SysAttrs.valueOf(keyString);
         } catch (IllegalArgumentException exc) {
             throw new UserException(POSIXErrno.POSIX_ERROR_EINVAL, "unknown system attribute '" + keyString + "'");
+        }
+
+        if (Logging.isDebug()) {
+            Logging.logMessage(Logging.LEVEL_DEBUG, null,
+                               "setSysAttrValue in MRCHelper: " +
+                                       "using key: %s", key);
         }
 
         switch (key) {

--- a/java/xtreemfs-servers/src/main/java/org/xtreemfs/osd/drain/OSDDrain.java
+++ b/java/xtreemfs-servers/src/main/java/org/xtreemfs/osd/drain/OSDDrain.java
@@ -63,6 +63,8 @@ import org.xtreemfs.pbrpc.generatedinterfaces.OSDServiceClient;
 
 /**
  * Class that provides function to remove a OSD by moving all his files to other OSDs.
+ *
+ * TODO this functionality should be handled by the MRC
  * 
  * @author bzcseife
  * 

--- a/java/xtreemfs-servers/src/test/java/org/xtreemfs/test/mrc/MRCTest.java
+++ b/java/xtreemfs-servers/src/test/java/org/xtreemfs/test/mrc/MRCTest.java
@@ -49,15 +49,17 @@ import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.StripingPolicyType;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.VivaldiCoordinates;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.XCap;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.XLocSet;
-import org.xtreemfs.pbrpc.generatedinterfaces.MRC;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.ACCESS_FLAGS;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.DirectoryEntries;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.Setattrs;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.Stat;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.Volumes;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.XAttr;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.listxattrResponse;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.xtreemfs_get_suitable_osdsResponse;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.xtreemfs_set_replica_update_policyRequest;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.xtreemfs_update_file_sizeRequest;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC.xtreemfs_replica_addRequest;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRCServiceClient;
 import org.xtreemfs.test.SetupUtils;
 import org.xtreemfs.test.TestEnvironment;
@@ -1316,7 +1318,7 @@ public class MRCTest {
                                0775, 0, getDefaultCoordinates()));
 
         // store the UUID of the OSD automatically assigned to the file
-        MRC.listxattrResponse listxattrResponse =
+        listxattrResponse listxattrResponse =
                 invokeSync(client.listxattr(mrcAddress, RPCAuthentication.authNone,
                                             uc, volumeName, fileName, false));
         String locations = null;
@@ -1345,7 +1347,7 @@ public class MRCTest {
                                                              RPCAuthentication.authNone,
                                                              uc, msg));
 
-        MRC.xtreemfs_get_suitable_osdsResponse suitable_osdsResponse =
+        xtreemfs_get_suitable_osdsResponse suitable_osdsResponse =
                 invokeSync(client.xtreemfs_get_suitable_osds(mrcAddress,
                                                              RPCAuthentication.authNone,
                                                             uc,
@@ -1361,8 +1363,8 @@ public class MRCTest {
                         .setStripingPolicy(sp)
                         .build();
 
-        MRC.xtreemfs_replica_addRequest xtreemfs_replica_addRequest =
-                MRC.xtreemfs_replica_addRequest.newBuilder()
+        xtreemfs_replica_addRequest xtreemfsReplicaAddRequest =
+                xtreemfs_replica_addRequest.newBuilder()
                         .setFileId(fileID)
                         .setNewReplica(replica)
                         .build();
@@ -1370,7 +1372,7 @@ public class MRCTest {
         invokeSync(client.xtreemfs_replica_add(mrcAddress,
                                                RPCAuthentication.authNone,
                                                uc,
-                                               xtreemfs_replica_addRequest));
+                                               xtreemfsReplicaAddRequest));
 
         // changes to the meta data database are performed in the background,
         // (the MRC sends the response before changes are made)

--- a/java/xtreemfs-servers/src/test/java/org/xtreemfs/test/mrc/MRCTest.java
+++ b/java/xtreemfs-servers/src/test/java/org/xtreemfs/test/mrc/MRCTest.java
@@ -9,6 +9,7 @@
 package org.xtreemfs.test.mrc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -37,6 +38,7 @@ import org.xtreemfs.foundation.pbrpc.generatedinterfaces.RPC.UserCredentials;
 import org.xtreemfs.mrc.ac.FileAccessManager;
 import org.xtreemfs.mrc.metadata.ReplicationPolicy;
 import org.xtreemfs.mrc.utils.Converter;
+import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.AccessControlPolicyType;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.FileCredentials;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.KeyValuePair;
@@ -47,6 +49,7 @@ import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.StripingPolicyType;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.VivaldiCoordinates;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.XCap;
 import org.xtreemfs.pbrpc.generatedinterfaces.GlobalTypes.XLocSet;
+import org.xtreemfs.pbrpc.generatedinterfaces.MRC;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.ACCESS_FLAGS;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.DirectoryEntries;
 import org.xtreemfs.pbrpc.generatedinterfaces.MRC.Setattrs;
@@ -91,8 +94,8 @@ public class MRCTest {
         // it to a new file on 'open')
         
         testEnv = new TestEnvironment(Services.DIR_CLIENT, Services.TIME_SYNC, Services.UUID_RESOLVER,
-            Services.MRC_CLIENT, Services.DIR_SERVICE, Services.MRC, Services.MOCKUP_OSD,
-            Services.MOCKUP_OSD2, Services.MOCKUP_OSD3);
+                                      Services.MRC_CLIENT, Services.DIR_SERVICE, Services.MRC,
+                                      Services.OSD, Services.OSD, Services.OSD);
         testEnv.start();
         
         client = testEnv.getMrcClient();
@@ -1288,6 +1291,147 @@ public class MRCTest {
         assertEquals(rp.getName(), xLoc.getReplicaUpdatePolicy());
         assertEquals(rp.getFactor(), xLoc.getReplicasCount());
     }
+
+    @Test
+    public void testMarkReplicaComplete() throws Exception {
+        final String uid = "userXY";
+        final List<String> gids = createGIDs("groupZ");
+        final String volumeName = "testVolume";
+        final UserCredentials uc = createUserCredentials(uid, gids);
+
+        final String fileName = "testFile";
+
+        // create volume and file
+        final StripingPolicy sp = StripingPolicy.newBuilder().setType(
+                StripingPolicyType.STRIPING_POLICY_RAID0).setStripeSize(64).setWidth(1).build();
+
+        invokeSync(client.xtreemfs_mkvol(mrcAddress, RPCAuthentication.authNone, uc,
+                                         AccessControlPolicyType.ACCESS_CONTROL_POLICY_NULL,
+                                         sp, "", 0, volumeName,
+                                         "", "",
+                                         getKVList(), 0));
+
+        invokeSync(client.open(mrcAddress, RPCAuthentication.authNone,
+                               uc, volumeName, fileName, FileAccessManager.O_CREAT,
+                               0775, 0, getDefaultCoordinates()));
+
+        // store the UUID of the OSD automatically assigned to the file
+        MRC.listxattrResponse listxattrResponse =
+                invokeSync(client.listxattr(mrcAddress, RPCAuthentication.authNone,
+                                            uc, volumeName, fileName, false));
+        String locations = null;
+        for (XAttr xAttr : listxattrResponse.getXattrsList()) {
+            if (xAttr.getName().equals("xtreemfs.locations")) {
+                 locations = xAttr.getValue();
+            }
+        }
+        String oldOSD = extractOSDUUIDs(locations).get(0);
+
+        String fileID = "";
+        for (XAttr xAttr: listxattrResponse.getXattrsList()) {
+            if (xAttr.getName().equals("xtreemfs.file_id")) {
+                fileID = xAttr.getValue();
+            }
+        }
+
+        // set the replica update policy and create a new full replica on a suitable OSD
+        xtreemfs_set_replica_update_policyRequest msg =
+                xtreemfs_set_replica_update_policyRequest.newBuilder()
+                        .setVolumeName(volumeName)
+                        .setPath(fileName)
+                        .setUpdatePolicy(ReplicaUpdatePolicies.REPL_UPDATE_PC_RONLY)
+                        .build();
+        invokeSync(client.xtreemfs_set_replica_update_policy(mrcAddress,
+                                                             RPCAuthentication.authNone,
+                                                             uc, msg));
+
+        MRC.xtreemfs_get_suitable_osdsResponse suitable_osdsResponse =
+                invokeSync(client.xtreemfs_get_suitable_osds(mrcAddress,
+                                                             RPCAuthentication.authNone,
+                                                            uc,
+                                                            fileID, "", "",
+                                                             0));
+
+        String newOSD = suitable_osdsResponse.getOsdUuidsList().get(0);
+
+        GlobalTypes.Replica replica =
+                GlobalTypes.Replica.newBuilder()
+                        .addOsdUuids(newOSD)
+                        .setReplicationFlags(ReplicationFlags.setRarestFirstStrategy(GlobalTypes.REPL_FLAG.REPL_FLAG_FULL_REPLICA.getNumber()))
+                        .setStripingPolicy(sp)
+                        .build();
+
+        MRC.xtreemfs_replica_addRequest xtreemfs_replica_addRequest =
+                MRC.xtreemfs_replica_addRequest.newBuilder()
+                        .setFileId(fileID)
+                        .setNewReplica(replica)
+                        .build();
+
+        invokeSync(client.xtreemfs_replica_add(mrcAddress,
+                                               RPCAuthentication.authNone,
+                                               uc,
+                                               xtreemfs_replica_addRequest));
+
+        // changes to the meta data database are performed in the background,
+        // (the MRC sends the response before changes are made)
+        // so we have to wait a little before starting the next change
+        Thread.sleep(200);
+
+        // try to remove the old replica - this should fail,
+        // as the new replica is not complete yet
+        try {
+            invokeSync(client.xtreemfs_replica_remove(mrcAddress,
+                                                      RPCAuthentication.authNone,
+                                                      uc,
+                                                      fileID,
+                                                      "", "",
+                                                      oldOSD));
+            fail("deleting the only complete replica should fail!");
+        } catch (PBRPCException e) {
+            // this exception is expected
+        }
+
+        // simulate that the OSD of the new replica has fetched all data of the file
+        invokeSync(client.xtreemfs_replica_mark_complete(mrcAddress,
+                                                         RPCAuthentication.authNone,
+                                                         uc,
+                                                         fileID,
+                                                         newOSD));
+
+        Thread.sleep(200);
+
+        // now that the new replica has all data and has been marked as complete,
+        // it should be possible to delete the old replica
+        try {
+            invokeSync(client.xtreemfs_replica_remove(mrcAddress,
+                                                      RPCAuthentication.authNone,
+                                                      uc,
+                                                      fileID,
+                                                      "", "",
+                                                      oldOSD));
+        } catch (PBRPCException e) {
+            fail("after marking the new replica complete, " +
+                         "deleting the old one should be possible!");
+        }
+
+        Thread.sleep(200);
+
+        listxattrResponse =
+                invokeSync(client.listxattr(mrcAddress, RPCAuthentication.authNone,
+                                            uc, volumeName, fileName, false));
+
+        for (XAttr xAttr : listxattrResponse.getXattrsList()) {
+            if (xAttr.getName().equals("xtreemfs.locations")) {
+                locations = xAttr.getValue();
+            }
+        }
+
+        // check whether the new replica is on the new OSD and the only replica
+        String currentOSD = extractOSDUUIDs(locations).get(0);
+        assertEquals(1, extractOSDUUIDs(locations).size());
+        assertEquals(newOSD, currentOSD);
+        assertNotEquals(oldOSD, currentOSD);
+    }
     
     @Test
     public void testReplicateOnClose() throws Exception {
@@ -1509,5 +1653,21 @@ public class MRCTest {
             kvList.add(KeyValuePair.newBuilder().setKey(kvPairs[i]).setValue(kvPairs[i + 1]).build());
         
         return kvList;
+    }
+
+    private static List<String> extractOSDUUIDs(String xAttrLocations) {
+        List<String> osdUUIDs = new LinkedList<String>();
+        if (xAttrLocations == null) {
+            return osdUUIDs;
+        }
+        String UUIDIdentifier = "\"uuid\":";
+        String splits [] = xAttrLocations.split(",");
+        for (String split : splits) {
+            if (split.startsWith(UUIDIdentifier)) {
+                osdUUIDs.add(split.substring(UUIDIdentifier.length() + 1,
+                                         split.length() - 1));
+            }
+        }
+        return osdUUIDs;
     }
 }


### PR DESCRIPTION
partially fixing issue 223: it is no longer possible to delete a replica of a file if it is the only complete one (i.e., has all the objects of that file).
deleting such a replica eventually becomes possible, when another OSD has a complete replica of that file.

if using read-only replication policy with a striping policy that uses more than one OSD per file, it might (with relatively low probability) still be possible to lose data, as described in issue 223.
