### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ script: |
   else
     if [[ $TEST_SUITE = "travis-junit-mrc" ]] || [[ $TEST_SUITE = "travis-junit-common-utils" ]] || [[ $TEST_SUITE = "travis-junit-osd" ]]; then
       make server
-      travis_wait 30 make client_debug
+ make client_debug
     elif [[ $TEST_SUITE = "travis-junit"* ]]; then
       make server
     else
-      travis_wait 30 make client_debug server hadoop-client
+ make client_debug server hadoop-client
     fi
     ./tests/xtestenv --clean-test-dir -x $XTREEMFS_DIR -t $TEST_DIR -c $XTREEMFS_DIR/tests/test_config.py -p $TEST_SUITE
   fi
@@ -87,3 +87,6 @@ deploy:
     repo: xtreemfs/xtreemfs
     tags: true
     condition: "$TEST_SUITE = travis-deploy"
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
