### PR TITLE
Dynamically adjust the number of Forked VM based on the number of CPU cores

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -152,7 +152,7 @@
         <configuration>
           <argLine>-Xms1024m -Xmx2048m -Djava.library.path=${libjni.directory}</argLine>
           <reuseForks>false</reuseForks>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
         </configuration>
       </plugin>
 


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
