### PR TITLE
Make it possible to build on modern Debian

### DIFF
--- a/contrib/hadoop/pom.xml
+++ b/contrib/hadoop/pom.xml
@@ -27,8 +27,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.source.version>1.6</java.source.version>
-    <java.target.version>1.6</java.target.version>
+    <java.source.version>11</java.source.version>
+    <java.target.version>11</java.target.version>
 
     <libjni.directory>${project.basedir}/../../cpp/build</libjni.directory>
 

--- a/contrib/server-repl-plugin/pom.xml
+++ b/contrib/server-repl-plugin/pom.xml
@@ -8,8 +8,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.source.version>1.6</java.source.version>
-    <java.target.version>1.6</java.target.version>
+    <java.source.version>11</java.source.version>
+    <java.target.version>11</java.target.version>
 
     <babudb-replication.version>0.6.0</babudb-replication.version>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -34,8 +34,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.source.version>1.6</java.source.version>
-    <java.target.version>1.6</java.target.version>
+    <java.source.version>11</java.source.version>
+    <java.target.version>11</java.target.version>
 
     <!-- Relative to 1st level childrens' basedirs -->
     <libjni.directory>${project.basedir}/../../cpp/build</libjni.directory>


### PR DESCRIPTION
Building xtreemfs on Debian 12 yields the following error:
```
[ERROR] Source option 6 is no longer supported. Use 7 or later.
[ERROR] Target option 6 is no longer supported. Use 7 or later.
```
Setting java.source.version and java.target.version to 11 in the pom.xml files make it possible to build on a modern OS. It would also allow for updating the dockerfiles in xtreemfs-docker repo to a modern OS.